### PR TITLE
Fix function signatures in Group Routes triggersEnter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,9 @@ You can group routes for better route organization. Here's an example:
 ~~~js
 var adminRoutes = FlowRouter.group({
   prefix: '/admin',
-  triggersEnter: [
-    function(path, next) {
-      console.log('running group triggers');
-      next();
-    }
-  ]
+  triggersEnter: [function(context, redirect) {
+    console.log('running group triggers');
+  }]
 });
 
 // handling /admin route
@@ -113,12 +110,9 @@ adminRoutes.route('/', {
   action: function() {
     FlowLayout.render('componentLayout', {content: 'admin'});
   },
-  triggersEnter: [
-    function(path, next) {
-      console.log('running /admin trigger');
-      next();
-    }
-  ]
+  triggersEnter: [function(context, redirect) {
+    console.log('running /admin trigger');
+  }]
 });
 
 // handling /admin/posts


### PR DESCRIPTION
I'm not 100% sure but looking through the code I think the group example is just out-dated and needs to match that of the route triggersEnter example.  Changed `Group Routes` examples to match that in `Redirecting With Triggers`.