### PR TITLE
Resolve #272 - use pathDef in internal code; expose current().route.pathDef

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ console.log(current);
 //     path: "/apps/this-is-my-app?show=yes&color=red",
 //     params: {appId: "this-is-my-app"},
 //     queryParams: {show: "yes", color: "red"}
-//     route: {name: "name-of-the-route"}
+//     route: {pathDef: "/apps/:appId", name: "name-of-the-route"}
 // }
 ~~~
 
@@ -480,7 +480,7 @@ Then the route object will be something like this:
 
 ~~~js
 {
-  path: '/blog/:post',
+  pathDef: '/blog/:post',
   name: 'postList',
   options: {customeField: 'customName'}
 }

--- a/client/group.js
+++ b/client/group.js
@@ -22,16 +22,16 @@ Group = function(router, options, parent) {
   }
 };
 
-Group.prototype.route = function(path, options, group) {
+Group.prototype.route = function(pathDef, options, group) {
   options = options || {};
 
-  if (!/^\/.*/.test(path)) {
+  if (!/^\/.*/.test(pathDef)) {
     var message = "route's path must start with '/'";
     throw new Error(message);
   }
 
   group = group || this;
-  path = this.prefix + path;
+  pathDef = this.prefix + pathDef;
 
   var triggersEnter = options.triggersEnter || [];
   options.triggersEnter = this._triggersEnter.concat(triggersEnter);
@@ -39,7 +39,7 @@ Group.prototype.route = function(path, options, group) {
   var triggersExit = options.triggersExit || [];
   options.triggersExit = triggersExit.concat(this._triggersExit);
 
-  return this._router.route(path, options, group);
+  return this._router.route(pathDef, options, group);
 };
 
 Group.prototype.group = function(options) {

--- a/client/route.js
+++ b/client/route.js
@@ -1,8 +1,12 @@
-Route = function(router, path, options, group) {
+Route = function(router, pathDef, options, group) {
   options = options || {};
 
   this.options = options;
-  this.path = path;
+  this.pathDef = pathDef
+
+  // Route.path is deprecated and will be removed in 3.0
+  this.path = pathDef;
+
   if (options.name) {
     this.name = options.name;
   }

--- a/client/router.js
+++ b/client/router.js
@@ -48,15 +48,15 @@ Router = function () {
   this._initTriggersAPI();
 };
 
-Router.prototype.route = function(path, options, group) {
-  if (!/^\/.*/.test(path)) {
+Router.prototype.route = function(pathDef, options, group) {
+  if (!/^\/.*/.test(pathDef)) {
     var message = "route's path must start with '/'";
     throw new Error(message);
   }
 
   options = options || {};
   var self = this;
-  var route = new Route(this, path, options, group);
+  var route = new Route(this, pathDef, options, group);
 
   // calls when the page route being activates
   route._actionHandle = function (context, next) {
@@ -122,7 +122,7 @@ Router.prototype.group = function(options) {
 
 Router.prototype.path = function(pathDef, fields, queryParams) {
   if (this._routesMap[pathDef]) {
-    pathDef = this._routesMap[pathDef].path;
+    pathDef = this._routesMap[pathDef].pathDef;
   }
 
   fields = fields || {};
@@ -186,7 +186,7 @@ Router.prototype.redirect = function(path) {
 Router.prototype.setParams = function(newParams) {
   if(!this._current.route) {return false;}
 
-  var pathDef = this._current.route.path;
+  var pathDef = this._current.route.pathDef;
   var existingParams = this._current.params;
   var params = {};
   _.each(_.keys(existingParams), function(key) {
@@ -212,7 +212,7 @@ Router.prototype.setQueryParams = function(newParams) {
     }
   }
 
-  var pathDef = this._current.route.path;
+  var pathDef = this._current.route.pathDef;
   var params = this._current.params;
   this.go(pathDef, params, queryParams);
   return true;
@@ -481,8 +481,8 @@ Router.prototype._updateCallbacks = function () {
   self._page.exits = [];
 
   _.each(self._routes, function(route) {
-    self._page(route.path, route._actionHandle);
-    self._page.exit(route.path, route._exitHandle);
+    self._page(route.pathDef, route._actionHandle);
+    self._page.exit(route.pathDef, route._exitHandle);
   });
 
   self._page("*", function(context) {
@@ -526,7 +526,7 @@ Router.prototype._triggerRouteRegister = function(currentRoute) {
   // object.
   // This is not to hide what's inside the route object, but to show 
   // these are the public APIs
-  var routePublicApi = _.pick(currentRoute, 'name', 'path');
+  var routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
   var omittingOptionFields = [
     'triggersEnter', 'triggersExit', 'action', 'subscriptions', 'name'
   ];

--- a/server/group.js
+++ b/server/group.js
@@ -5,9 +5,9 @@ Group = function(router, options) {
   this._router = router;
 };
 
-Group.prototype.route = function(path, options) {
-  path = this.prefix + path;
-  return this._router.route(path, options);
+Group.prototype.route = function(pathDef, options) {
+  pathDef = this.prefix + pathDef;
+  return this._router.route(pathDef, options);
 };
 
 Group.prototype.group = function(options) {

--- a/server/plugins/fast_render.js
+++ b/server/plugins/fast_render.js
@@ -13,7 +13,7 @@ Meteor.startup(function () {
 
 function setupFastRender () {
   _.each(FlowRouter._routes, function (route) {
-    FastRender.route(route.path, function (routeParams, path) {
+    FastRender.route(route.pathDef, function (routeParams, path) {
       var self = this;
 
       // anyone using Meteor.subscribe for something else?

--- a/server/route.js
+++ b/server/route.js
@@ -1,8 +1,12 @@
-Route = function(router, path, options) {
+Route = function(router, pathDef, options) {
   options = options || {};
   this.options = options;
   this.name = options.name;
-  this.path = path;
+  this.pathDef = pathDef;
+
+  // Route.path is deprecated and will be removed in 3.0
+  this.path = pathDef;
+
   this.action = options.action || Function.prototype;
   this.subscriptions = options.subscriptions || Function.prototype;
   this._subsMap = {};

--- a/server/router.js
+++ b/server/router.js
@@ -9,14 +9,14 @@ Router = function () {
   this._onRouteCallbacks = [];
 };
 
-Router.prototype.route = function(path, options) {
-  if (!/^\/.*/.test(path)) {
+Router.prototype.route = function(pathDef, options) {
+  if (!/^\/.*/.test(pathDef)) {
     var message = "route's path must start with '/'";
     throw new Error(message);
   }
   
   options = options || {};
-  var route = new Route(this, path, options);
+  var route = new Route(this, pathDef, options);
   this._routes.push(route);
 
   if (options.name) {
@@ -71,7 +71,7 @@ Router.prototype._triggerRouteRegister = function(currentRoute) {
   // object.
   // This is not to hide what's inside the route object, but to show 
   // these are the public APIs
-  var routePublicApi = _.pick(currentRoute, 'name', 'path');
+  var routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
   var omittingOptionFields = [
     'triggersEnter', 'triggersExit', 'action', 'subscriptions', 'name'
   ];

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -91,12 +91,12 @@ Tinytest.addAsync('Client - Router - redirect using FlowRouter.go', function (te
 Tinytest.addAsync('Client - Router - get current route path', function (test, next) {
   var value = Random.id();
   var randomValue = Random.id();
-  var routePath = "/" + randomValue + '/:_id';
+  var pathDef = "/" + randomValue + '/:_id';
   var path = "/" + randomValue + "/" + value;
 
   var detectedValue = null;
 
-  FlowRouter.route(routePath, {
+  FlowRouter.route(pathDef, {
     action: function(params) {
       detectedValue = params._id;
     }
@@ -348,7 +348,7 @@ Tinytest.addAsync('Client - Router - notFound', function (test, done) {
 
 Tinytest.addAsync('Client - Router - withReplaceState - enabled', 
 function (test, done) {
-  var path = "/" + Random.id() + "/:id";
+  var pathDef = "/" + Random.id() + "/:id";
   var originalRedirect = FlowRouter._page.replace;
   var callCount = 0;
   FlowRouter._page.replace = function(path) {
@@ -356,7 +356,7 @@ function (test, done) {
     originalRedirect.call(FlowRouter._page, path);
   };
 
-  FlowRouter.route(path, {
+  FlowRouter.route(pathDef, {
     name: name,
     action: function(params) {
       test.equal(params.id, "awesome");
@@ -370,13 +370,13 @@ function (test, done) {
   });
 
   FlowRouter.withReplaceState(function() {
-    FlowRouter.go(path, {id: "awesome"});
+    FlowRouter.go(pathDef, {id: "awesome"});
   });
 });
 
 Tinytest.addAsync('Client - Router - withReplaceState - disabled', 
 function (test, done) {
-  var path = "/" + Random.id() + "/:id";
+  var pathDef = "/" + Random.id() + "/:id";
   var originalRedirect = FlowRouter._page.replace;
   var callCount = 0;
   FlowRouter._page.replace = function(path) {
@@ -384,7 +384,7 @@ function (test, done) {
     originalRedirect.call(FlowRouter._page, path);
   };
 
-  FlowRouter.route(path, {
+  FlowRouter.route(pathDef, {
     name: name,
     action: function(params) {
       test.equal(params.id, "awesome");
@@ -394,7 +394,7 @@ function (test, done) {
     }
   });
 
-  FlowRouter.go(path, {id: "awesome"});
+  FlowRouter.go(pathDef, {id: "awesome"});
 });
 
 Tinytest.addAsync('Client - Router - withTrailingSlash - enabled', function (test, next) {

--- a/test/common/route.spec.js
+++ b/test/common/route.spec.js
@@ -1,11 +1,11 @@
 Router = FlowRouter.Router;
 
 Tinytest.addAsync('Common - Route - expose route options', function (test, next) {
-  var path = "/" + Random.id();
+  var pathDef = "/" + Random.id();
   var name = Random.id();
   var data = {aa: 10};
   
-  FlowRouter.route(path, {
+  FlowRouter.route(pathDef, {
     name: name,
     someData: data
   });

--- a/test/common/router.addons.spec.js
+++ b/test/common/router.addons.spec.js
@@ -3,11 +3,15 @@ Router = FlowRouter.Router;
 Tinytest.addAsync('Common - Addons - onRouteRegister basic usage', function (test, done) {
   var name = Random.id();
   var customField = Random.id();
-  var path = '/' + name;
+  var pathDef = '/' + name;
   
   FlowRouter.onRouteRegister(function(route) {
     test.equal(route, {
-      path: path,
+      pathDef: pathDef,
+
+      // Route.path is deprecated and will be removed in 3.0
+      path: pathDef,
+
       name: name,
       options: {customField: customField}
     });  
@@ -15,7 +19,7 @@ Tinytest.addAsync('Common - Addons - onRouteRegister basic usage', function (tes
     done();
   });
 
-  FlowRouter.route(path, {
+  FlowRouter.route(pathDef, {
     name: name,
     action: function() {},
     subscriptions: function() {},


### PR DESCRIPTION
Standardize on "pathDef" in internal code.

Existing public API, `Router.current().route.path`, is left unchanged but called out in the code as being deprecated for removal in 3.0.