### PR TITLE
Allow triggers to stop the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,34 @@ Every trigger callback comes with a second argument: a function you can use to r
 
 Check this [PR](https://github.com/meteorhacks/flow-router/pull/172) to learn more about our redirect API.
 
+#### Stopping the Callback With Triggers
+
+In some cases, you may need to stop the route callback from firing using triggers. You can do this in **before** triggers, using the third argument: the `stop` function. For example, you can check the prefix and if it fails, show the notFound layout and stop before the action fires.
+
+```js
+var localeGroup = FlowRouter.group({
+  prefix: '/:locale?',
+  triggersEnter: [localeCheck]
+});
+
+localeGroup.route('/login', {
+  action: function (params, queryParams) {
+    BlazeLayout.render('componentLayout', {content: 'login'});
+  }
+});
+
+function localeCheck(context, redirect, stop) {
+  var locale = context.params.locale;
+
+  if (locale !== undefined && locale !== 'fr') {
+    BlazeLayout.render('notFound');
+    stop();
+  }
+}
+```
+
+> **Note**: When using the stop function, you should always pass the second **redirect** argument, even if you won't use it.
+
 ## Not Found Routes
 
 You can configure Not Found routes like this:

--- a/client/triggers.js
+++ b/client/triggers.js
@@ -64,7 +64,7 @@ Triggers.createRouteBoundTriggers = function(triggers, names, negate) {
   return filteredTriggers;
 };
 
-//  run triggers and abort if redirected
+//  run triggers and abort if redirected or callback stopped
 //  @triggers - a set of triggers 
 //  @context - context we need to pass (it must have the route)
 //  @redirectFn - function which used to redirect 
@@ -76,7 +76,7 @@ Triggers.runTriggers = function(triggers, context, redirectFn, after) {
 
   for(var lc=0; lc<triggers.length; lc++) {
     var trigger = triggers[lc];
-    trigger(context, doRedirect);
+    trigger(context, doRedirect, doStop);
 
     if(abort) {
       return;
@@ -104,5 +104,9 @@ Triggers.runTriggers = function(triggers, context, redirectFn, after) {
     abort = true;
     alreadyRedirected = true;
     redirectFn(url, params, queryParams);
+  }
+
+  function doStop() {
+    abort = true;
   }
 };

--- a/test/client/trigger.spec.js
+++ b/test/client/trigger.spec.js
@@ -463,6 +463,31 @@ Tinytest.addAsync('Client - Triggers - redirect from exit', function(test, next)
   }, 100);
 });
 
+Tinytest.addAsync('Client - Triggers - stop callback from enter', function(test, next) {
+  var rand = Random.id();
+  var log = [];
+
+  FlowRouter.route('/' + rand, {
+    triggersEnter: [function(context, redirect, stop) {
+      log.push(10);
+      stop();
+    }, function() {
+      throw new Error("should not execute this trigger");
+    }],
+    action: function(_params) {
+      throw new Error("should not execute the action");
+    }
+  });
+
+  FlowRouter.go('/');
+  FlowRouter.go('/' + rand);
+
+  setTimeout(function() {
+    test.equal(log, [10]);
+    next();
+  }, 100);
+});
+
 Tinytest.addAsync(
 'Client - Triggers - invalidate inside an autorun', 
 function(test, next) {

--- a/test/client/triggers.js
+++ b/test/client/triggers.js
@@ -97,6 +97,24 @@ function(test, done) {
 });
 
 Tinytest.addAsync(
+'Triggers - runTriggers - stop callback',
+function(test, done) {
+  var store = [];
+  var triggers = MakeTriggers(2, store);
+  triggers.splice(1, 0, function(context, redirect, stop) {
+    stop();
+  });
+
+  Triggers.runTriggers(triggers, null, null, function() {
+    store.push(2);
+  });
+
+  test.equal(store, [0]);
+  done();
+});
+
+
+Tinytest.addAsync(
 'Triggers - runTriggers - get context',
 function(test, done) {
   var context = {};


### PR DESCRIPTION
Related to [issue #304](https://github.com/kadirahq/flow-router/issues/304).

Now we can call `stop()` function in triggersEnter to stop the callback from firing. For example, we can show the notFound page and stop before firing the route's action.