### PR TITLE
add hashbang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,11 +599,14 @@ meteor add tomwasd:history-polyfill
 
 ## Hashbang URLs
 
-To enable hashbang urls like `mydomain.com/#!/mypath` simple set the `hashbang` option to `true`.
-Do this outside of a `Meteor.startup()` function, or before you initialize FlowRouter:
+To enable hashbang urls like `mydomain.com/#!/mypath` simple set the `hashbang` option to `true` in the initialize funtion:
 
 ~~~js
-FlowRouter.hashbang = true;
+// file: app.js
+FlowRouter.wait();
+WhenEverYourAppIsReady(function() {
+  FlowRouter.initialize({hashbang: true});
+});
 ~~~
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It exposes a great API for changing the URL and reactively getting data from the
 * [API](#api)
 * [Subscription Management](#subscription-management)
 * [IE9 Support](#ie9-support)
+* [Hashbang URLs](#hashbang-urls)
 * [Addons](#addons)
 * [Difference with Iron Router](#difference-with-iron-router)
 * [Migrating into 2.0](#migrating-into-20)
@@ -595,6 +596,16 @@ If you need to support IE9, add the **HTML5 history polyfill** with the followin
 ~~~shell
 meteor add tomwasd:history-polyfill
 ~~~
+
+## Hashbang URLs
+
+To enable hashbang urls like `mydomain.com/#!/mypath` simple set the `hashbang` option to `true`.
+Do this outside of a `Meteor.startup()` function, or before you initialize FlowRouter:
+
+~~~js
+FlowRouter.hashbang = true;
+~~~
+
 
 ## Addons
 

--- a/client/router.js
+++ b/client/router.js
@@ -322,7 +322,9 @@ Router.prototype._notfoundRoute = function(context) {
   this._invalidateTracker();
 };
 
-Router.prototype.initialize = function() {
+Router.prototype.initialize = function(options) {
+  options = options || {};
+
   if(this._initialized) {
     throw new Error("FlowRouter is already initialized");
   }
@@ -355,7 +357,7 @@ Router.prototype.initialize = function() {
   // in unpredicatable manner. See #168
   // this is the default behaviour and we need keep it like that
   // we are doing a hack. see .path()
-  this._page({decodeURLComponents: true, hashbang: !!this.hashbang});
+  this._page({decodeURLComponents: true, hashbang: !!options.hashbang});
   this._initialized = true;
 };
 

--- a/client/router.js
+++ b/client/router.js
@@ -355,7 +355,7 @@ Router.prototype.initialize = function() {
   // in unpredicatable manner. See #168
   // this is the default behaviour and we need keep it like that
   // we are doing a hack. see .path()
-  this._page({decodeURLComponents: true});
+  this._page({decodeURLComponents: true, hashbang: !!this.hashbang});
   this._initialized = true;
 };
 


### PR DESCRIPTION
This PR adds the possibility to switch to hashing urls `#!/path/more` instead of `/path/more`

Simpy set the `FlowRouter.hashbang` property to `true` before you FlowRouter initialises 