### PR TITLE
Support prefixed paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It exposes a great API for changing the URL and reactively getting data from the
 * [Subscription Management](#subscription-management)
 * [IE9 Support](#ie9-support)
 * [Hashbang URLs](#hashbang-urls)
+* [Prefixed paths](#prefixed-paths)
 * [Addons](#addons)
 * [Difference with Iron Router](#difference-with-iron-router)
 * [Migrating into 2.0](#migrating-into-20)
@@ -637,6 +638,9 @@ WhenEverYourAppIsReady(function() {
 });
 ~~~
 
+## Prefixed paths
+
+In cases you wish to run multiple web application on the same domain name, you’ll probably want to serve your particular meteor application under a sub-path (eg `example.com/myapp`). In this case simply include the path prefix in the meteor `ROOT_URL` environment variable and FlowRouter will handle it transparently without any additional configuration.
 
 ## Addons
 

--- a/client/router.js
+++ b/client/router.js
@@ -137,9 +137,16 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
     pathDef = this._routesMap[pathDef].pathDef;
   }
 
+  var path = "";
+
+  // Prefix the path with the router global prefix
+  if (this._basePath) {
+    path += this._basePath + "/";
+  }
+
   fields = fields || {};
   var regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
-  var path = pathDef.replace(regExp, function(key) {
+  path += pathDef.replace(regExp, function(key) {
     var firstRegexpChar = key.indexOf("(");
     // get the content behind : and (\\d+/)
     key = key.substring(1, (firstRegexpChar > 0)? firstRegexpChar: undefined);
@@ -153,7 +160,8 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
     return encodeURIComponent(encodeURIComponent(fields[key] || ""));
   });
 
-  path = path.replace(/\/\/+/g, "/"); // Replace multiple slashes with single slash
+  // Replace multiple slashes with single slash
+  path = path.replace(/\/\/+/g, "/");
 
   // remove trailing slash
   // but keep the root slash if it's the only one

--- a/client/router.js
+++ b/client/router.js
@@ -369,12 +369,11 @@ Router.prototype.initialize = function(options) {
   // in unpredicatable manner. See #168
   // this is the default behaviour and we need keep it like that
   // we are doing a hack. see .path()
+  this._page.base(this._basePath);
   this._page({
-    basePath: this._basePath,
     decodeURLComponents: true,
     hashbang: !!options.hashbang
   });
-  this._page.base(this._basePath);
 
   this._initialized = true;
 };

--- a/client/router.js
+++ b/client/router.js
@@ -141,7 +141,7 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
 
   // Prefix the path with the router global prefix
   if (this._basePath) {
-    path += this._basePath + "/";
+    path += "/" + this._basePath + "/";
   }
 
   fields = fields || {};

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -574,7 +574,6 @@ Tinytest.addAsync(
 'Client - Router - base path - url updated',
 function(test, done) {
   var simulatedBasePath = '/flow';
-  var previousBasePath = FlowRouter._basePath;
   var rand = Random.id();
   FlowRouter.route('/' + rand, { action: function() {} });
 
@@ -582,7 +581,7 @@ function(test, done) {
   FlowRouter.go('/' + rand);
   setTimeout(function() {
     test.equal(location.pathname, simulatedBasePath + '/' + rand);
-    setBasePath(previousBasePath);
+    resetBasePath();
     done();
   }, 100);
 });
@@ -591,11 +590,10 @@ Tinytest.addAsync(
 'Client - Router - base path - route action called',
 function(test, done) {
   var simulatedBasePath = '/flow';
-  var previousBasePath = FlowRouter._basePath;
   var rand = Random.id();
   FlowRouter.route('/' + rand, {
     action: function() {
-      setBasePath(previousBasePath);
+      resetBasePath();
       done();
     }
   });
@@ -604,11 +602,27 @@ function(test, done) {
   FlowRouter.go('/' + rand);
 });
 
+Tinytest.add(
+'Client - Router - base path - path generation',
+function(test, done) {
+  _.each(['/flow', '/flow/', 'flow/', 'flow'], function(simulatedBasePath) {
+    var rand = Random.id();
+    setBasePath(simulatedBasePath);
+    test.equal(FlowRouter.path('/' + rand), '/flow/' + rand);
+  });
+  resetBasePath();
+});
+
 
 function setBasePath(path) {
   FlowRouter._initialized = false;
   FlowRouter._basePath = path;
   FlowRouter.initialize();
+}
+
+var defaultBasePath = FlowRouter._basePath;
+function resetBasePath() {
+  setBasePath(defaultBasePath);
 }
 
 function bind(obj, method) {

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -346,7 +346,7 @@ Tinytest.addAsync('Client - Router - notFound', function (test, done) {
   }, 50);
 });
 
-Tinytest.addAsync('Client - Router - withReplaceState - enabled', 
+Tinytest.addAsync('Client - Router - withReplaceState - enabled',
 function (test, done) {
   var pathDef = "/" + Random.id() + "/:id";
   var originalRedirect = FlowRouter._page.replace;
@@ -362,7 +362,7 @@ function (test, done) {
       test.equal(params.id, "awesome");
       test.equal(callCount, 1);
       FlowRouter._page.replace = originalRedirect;
-      // We don't use Meteor.defer here since it carries 
+      // We don't use Meteor.defer here since it carries
       // Meteor.Environment vars too
       // Which breaks our test below
       setTimeout(done, 0);
@@ -374,7 +374,7 @@ function (test, done) {
   });
 });
 
-Tinytest.addAsync('Client - Router - withReplaceState - disabled', 
+Tinytest.addAsync('Client - Router - withReplaceState - disabled',
 function (test, done) {
   var pathDef = "/" + Random.id() + "/:id";
   var originalRedirect = FlowRouter._page.replace;
@@ -537,7 +537,7 @@ function (test, next) {
 });
 
 Tinytest.addAsync(
-'Client - Router - wait - before initialize', 
+'Client - Router - wait - before initialize',
 function(test, done) {
   FlowRouter._initialized = false;
   FlowRouter.wait();
@@ -549,7 +549,7 @@ function(test, done) {
 });
 
 Tinytest.addAsync(
-'Client - Router - wait - after initialized', 
+'Client - Router - wait - after initialized',
 function(test, done) {
   try {
     FlowRouter.wait();
@@ -560,7 +560,7 @@ function(test, done) {
 });
 
 Tinytest.addAsync(
-'Client - Router - initialize - after initialized', 
+'Client - Router - initialize - after initialized',
 function(test, done) {
   try {
     FlowRouter.initialize();
@@ -569,6 +569,47 @@ function(test, done) {
     done();
   }
 });
+
+Tinytest.addAsync(
+'Client - Router - base path - url updated',
+function(test, done) {
+  var simulatedBasePath = '/flow';
+  var previousBasePath = FlowRouter._basePath;
+  var rand = Random.id();
+  FlowRouter.route('/' + rand, { action: function() {} });
+
+  setBasePath(simulatedBasePath);
+  FlowRouter.go('/' + rand);
+  setTimeout(function() {
+    test.equal(location.pathname, simulatedBasePath + '/' + rand);
+    setBasePath(previousBasePath);
+    done();
+  }, 100);
+});
+
+Tinytest.addAsync(
+'Client - Router - base path - route action called',
+function(test, done) {
+  var simulatedBasePath = '/flow';
+  var previousBasePath = FlowRouter._basePath;
+  var rand = Random.id();
+  FlowRouter.route('/' + rand, {
+    action: function() {
+      setBasePath(previousBasePath);
+      done();
+    }
+  });
+
+  setBasePath(simulatedBasePath);
+  FlowRouter.go('/' + rand);
+});
+
+
+function setBasePath(path) {
+  FlowRouter._initialized = false;
+  FlowRouter._basePath = path;
+  FlowRouter.initialize();
+}
 
 function bind(obj, method) {
   return function() {


### PR DESCRIPTION
Fixes #315 

---

*Currently, this does __not__ work.* I'm having some trouble understanding `pagejs` behaviour and internals distinctions between a `canonicalPath` and `path`, and why the URL isn’t correctly modified even when `pagejs` is internally aware of the base path.