### PR TITLE
Cross domain redirect exception

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -45,6 +45,10 @@ Router = function () {
 
   // redirect function used inside triggers
   this._redirectFn = function(pathDef, fields, queryParams) {
+    if (/^http(s)?:\/\//.test(pathDef)) {
+        var message = "Redirects to URLs outside of the app are not supported in this version of Flow Router. Use 'window.location = yourUrl' instead";
+        throw new Error(message);
+    }
     self.withReplaceState(function() {
       var path = FlowRouter.path(pathDef, fields, queryParams);
       self._page.redirect(path);

--- a/test/client/trigger.spec.js
+++ b/test/client/trigger.spec.js
@@ -463,6 +463,46 @@ Tinytest.addAsync('Client - Triggers - redirect from exit', function(test, next)
   }, 100);
 });
 
+Tinytest.addAsync('Client - Triggers - redirect to external URL fails', function(test, next) {
+  var rand = Random.id(), rand2 = Random.id();
+  var log = [];
+
+  // testing "http://" URLs
+  FlowRouter.route('/' + rand, {
+    triggersEnter: [function(context, redirect) {
+      test.throws(function() {
+          redirect("http://example.com/")
+      }, "Redirects to URLs outside of the app are not supported")
+    }],
+    action: function(_params) {
+      log.push(1);
+    },
+    name: rand
+  });
+
+  // testing "https://" URLs
+  FlowRouter.route('/' + rand2, {
+    triggersEnter: [function(context, redirect) {
+      test.throws(function() {
+          redirect("https://example.com/")
+      })
+    }],
+    action: function(_params) {
+      log.push(2);
+    },
+    name: rand2
+  });
+
+  FlowRouter.go('/');
+  FlowRouter.go('/' + rand);
+  FlowRouter.go('/' + rand2);
+
+  setTimeout(function() {
+    test.equal(log, []);
+    next();
+  }, 300);
+});
+
 Tinytest.addAsync('Client - Triggers - stop callback from enter', function(test, next) {
   var rand = Random.id();
   var log = [];


### PR DESCRIPTION
This pull request adds a test to check if URLs passed to the redirect function in triggers are external to the app and throws an exception if so.

Basically, URLs that start with 'http://' or 'https://' raise an exception.

The pull request adds also a TinyTest test to check this functionality.

I send this pull request because of [this](https://github.com/kadirahq/flow-router/issues/327) issue.