### PR TITLE
Persist options object on route groups

### DIFF
--- a/client/group.js
+++ b/client/group.js
@@ -9,6 +9,7 @@ Group = function(router, options, parent) {
   this._router = router;
   this.prefix = options.prefix || '';
   this.name = options.name;
+  this.options = options;
 
   this._triggersEnter = options.triggersEnter || [];
   this._triggersExit = options.triggersExit || [];

--- a/package.js
+++ b/package.js
@@ -48,6 +48,7 @@ Package.onTest(function(api) {
   api.addFiles('test/common/router.path.spec.js', ['client', 'server']);
   api.addFiles('test/common/router.addons.spec.js', ['client', 'server']);
   api.addFiles('test/common/route.spec.js', ['client', 'server']);
+  api.addFiles('test/common/group.spec.js', ['client', 'server']);
 });
 
 function configure(api) {

--- a/server/group.js
+++ b/server/group.js
@@ -1,7 +1,7 @@
 Group = function(router, options) {
   options = options || {};
   this.prefix = options.prefix || '';
-
+  this.options = options;
   this._router = router;
 };
 

--- a/test/client/group.spec.js
+++ b/test/client/group.spec.js
@@ -87,3 +87,27 @@ Tinytest.addAsync('Client - Group - set and retrieve group name', function (test
     next();
   }, 100);
 });
+
+Tinytest.add('Client - Group - expose group options on a route', function (test) {
+  var pathDef = "/" + Random.id();
+  var name = Random.id();
+  var groupName = Random.id();
+  var data = {aa: 10};
+  var layout = 'blah';
+
+  var group = FlowRouter.group({
+    name: groupName,
+    prefix: '/admin',
+    layout: layout,
+    someData: data
+  });
+
+  group.route(pathDef, {
+    name: name
+  });
+
+  var route = FlowRouter._routesMap[name];
+
+  test.equal(route.group.options.someData, data);
+  test.equal(route.group.options.layout, layout);
+});

--- a/test/common/group.spec.js
+++ b/test/common/group.spec.js
@@ -1,0 +1,16 @@
+Tinytest.add('Common - Group - expose group options', function (test) {
+  var pathDef = "/" + Random.id();
+  var name = Random.id();
+  var data = {aa: 10};
+  var layout = 'blah';
+
+  var group = FlowRouter.group({
+    name: name,
+    prefix: '/admin',
+    layout: layout,
+    someData: data
+  });
+
+  test.equal(group.options.someData, data);
+  test.equal(group.options.layout, layout);
+});


### PR DESCRIPTION
Addressing #375.

This patch saves the `options` object on a group, so it can be retrieved from a route later.

```js
const group = FlowRouter.group({
  name: 'admin',
  prefix: '/admin',
  layout: 'AdminLayout'
});

group.route('/path', {
  action() {
    // this.group.options will here be:
    // { name: 'admin', prefix: '/admin', layout: 'AdminLayout' }
    BlazeLayout.render(this.group.options.layout, 'template');
  }
});
```

My first idea was to omit the `name` and `prefix` properties when attaching on the group, but that would be inconsistent with how it's done for a `Route`.