### PR TITLE
Ignore browserify cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .build*
+*.browserify.js.cached
+*.browserify.js.map


### PR DESCRIPTION
There are some temporary files being created by `cosmos:browserify`. We should probably not commit them.