### PR TITLE
Adds Npm 'url' as a proper package dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,12 +7,13 @@ Package.describe({
 
 Npm.depends({
   'deepmerge': '0.2.10',
-  "connect": "2.13.0",
+  'connect': '2.13.0',
   'cheerio': '0.19.0',
   // In order to support IE9, we had to fork pagejs and apply
   // this PR: https://github.com/visionmedia/page.js/pull/288
-  'page':'https://github.com/kadirahq/page.js/archive/f29d4d4491178b285b9058c32d74975a4f945dea.tar.gz',
-  'qs':'3.1.0'
+  'page': 'https://github.com/kadirahq/page.js/archive/f29d4d4491178b285b9058c32d74975a4f945dea.tar.gz',
+  'qs': '3.1.0',
+  'url': '0.11.0'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
and cleans up formatting inconsistencies of a few others.

There's an Npm.require('url') call in [/server/route.js](https://github.com/kadirahq/flow-router/blob/ssr/server/route.js) but no package-level dependency.