### PR TITLE
converted code to es2015 syntax

### DIFF
--- a/client/_init.js
+++ b/client/_init.js
@@ -4,7 +4,7 @@ FlowRouter.Router = Router;
 FlowRouter.Route = Route;
 
 // Initialize FlowRouter
-Meteor.startup(function () {
+Meteor.startup(() => {
   if(!FlowRouter._askedToWait) {
     FlowRouter.initialize();
   }

--- a/client/group.js
+++ b/client/group.js
@@ -1,57 +1,59 @@
-Group = function(router, options, parent) {
-  options = options || {};
+Group = class {
+  constructor(router, options, parent) {
+    options = options || {};
 
-  if (options.prefix && !/^\/.*/.test(options.prefix)) {
-    var message = "group's prefix must start with '/'";
-    throw new Error(message);
+    if (options.prefix && !/^\/.*/.test(options.prefix)) {
+      const message = "group's prefix must start with '/'";
+      throw new Error(message);
+    }
+
+    this._router = router;
+    this.prefix = options.prefix || '';
+    this.name = options.name;
+    this.options = options;
+
+    this._triggersEnter = options.triggersEnter || [];
+    this._triggersExit = options.triggersExit || [];
+    this._subscriptions = options.subscriptions || Function.prototype;
+
+    this.parent = parent;
+    if (this.parent) {
+      this.prefix = parent.prefix + this.prefix;
+
+      this._triggersEnter = parent._triggersEnter.concat(this._triggersEnter);
+      this._triggersExit = this._triggersExit.concat(parent._triggersExit);
+    }
   }
 
-  this._router = router;
-  this.prefix = options.prefix || '';
-  this.name = options.name;
-  this.options = options;
+  route(pathDef, options, group) {
+    options = options || {};
 
-  this._triggersEnter = options.triggersEnter || [];
-  this._triggersExit = options.triggersExit || [];
-  this._subscriptions = options.subscriptions || Function.prototype;
+    if (!/^\/.*/.test(pathDef)) {
+      const message = "route's path must start with '/'";
+      throw new Error(message);
+    }
 
-  this.parent = parent;
-  if (this.parent) {
-    this.prefix = parent.prefix + this.prefix;
+    group = group || this;
+    pathDef = this.prefix + pathDef;
 
-    this._triggersEnter = parent._triggersEnter.concat(this._triggersEnter);
-    this._triggersExit = this._triggersExit.concat(parent._triggersExit);
-  }
-};
+    const triggersEnter = options.triggersEnter || [];
+    options.triggersEnter = this._triggersEnter.concat(triggersEnter);
 
-Group.prototype.route = function(pathDef, options, group) {
-  options = options || {};
+    const triggersExit = options.triggersExit || [];
+    options.triggersExit = triggersExit.concat(this._triggersExit);
 
-  if (!/^\/.*/.test(pathDef)) {
-    var message = "route's path must start with '/'";
-    throw new Error(message);
+    return this._router.route(pathDef, options, group);
   }
 
-  group = group || this;
-  pathDef = this.prefix + pathDef;
-
-  var triggersEnter = options.triggersEnter || [];
-  options.triggersEnter = this._triggersEnter.concat(triggersEnter);
-
-  var triggersExit = options.triggersExit || [];
-  options.triggersExit = triggersExit.concat(this._triggersExit);
-
-  return this._router.route(pathDef, options, group);
-};
-
-Group.prototype.group = function(options) {
-  return new Group(this._router, options, this);
-};
-
-Group.prototype.callSubscriptions = function(current) {
-  if (this.parent) {
-    this.parent.callSubscriptions(current);
+  group(options) {
+    return new Group(this._router, options, this);
   }
 
-  this._subscriptions.call(current.route, current.params, current.queryParams);
-};
+  callSubscriptions(current) {
+    if (this.parent) {
+      this.parent.callSubscriptions(current);
+    }
+
+    this._subscriptions.call(current.route, current.params, current.queryParams);
+  }
+}

--- a/client/route.js
+++ b/client/route.js
@@ -1,97 +1,102 @@
-Route = function(router, pathDef, options, group) {
-  options = options || {};
+Route = class {
+  constructor(router, pathDef, options, group) {
+    options = options || {};
 
-  this.options = options;
-  this.pathDef = pathDef
+    this.options = options;
+    this.pathDef = pathDef
 
-  // Route.path is deprecated and will be removed in 3.0
-  this.path = pathDef;
+    // Route.path is deprecated and will be removed in 3.0
+    this.path = pathDef;
 
-  if (options.name) {
-    this.name = options.name;
+    if (options.name) {
+      this.name = options.name;
+    }
+
+    this._action = options.action || Function.prototype;
+    this._triggersEnter = options.triggersEnter || [];
+    this._triggersExit = options.triggersExit || [];
+    this._router = router;
+
+    this._params = new ReactiveDict();
+    this._queryParams = new ReactiveDict();
+    this._routeCloseDep = new Tracker.Dependency();
+
+    // tracks the changes in the URL
+    this._pathChangeDep = new Tracker.Dependency();
+
+    this.group = group;
   }
 
-  this._action = options.action || Function.prototype;
-  this._triggersEnter = options.triggersEnter || [];
-  this._triggersExit = options.triggersExit || [];
-  this._router = router;
+  callAction(current) {
+    this._action(current.params, current.queryParams);
+  }
 
-  this._params = new ReactiveDict();
-  this._queryParams = new ReactiveDict();
-  this._routeCloseDep = new Tracker.Dependency();
+  getRouteName() {
+    this._routeCloseDep.depend();
+    return this.name;
+  }
 
-  // tracks the changes in the URL
-  this._pathChangeDep = new Tracker.Dependency();
+  getParam(key) {
+    this._routeCloseDep.depend();
+    return this._params.get(key);
+  }
 
-  this.group = group;
-};
+  getQueryParam(key) {
+    this._routeCloseDep.depend();
+    return this._queryParams.get(key);
+  }
 
-Route.prototype.callAction = function(current) {
-  var self = this;
-  self._action(current.params, current.queryParams);
-};
+  watchPathChange() {
+    this._pathChangeDep.depend();
+  }
 
-
-Route.prototype.getRouteName = function() {
-  this._routeCloseDep.depend();
-  return this.name;
-};
-
-Route.prototype.getParam = function(key) {
-  this._routeCloseDep.depend();
-  return this._params.get(key);
-};
-
-Route.prototype.getQueryParam = function(key) {
-  this._routeCloseDep.depend();
-  return this._queryParams.get(key);
-};
-
-Route.prototype.watchPathChange = function() {
-  this._pathChangeDep.depend();
-};
-
-Route.prototype.registerRouteClose = function() {
-  this._params = new ReactiveDict();
-  this._queryParams = new ReactiveDict();
-  this._routeCloseDep.changed();
-  this._pathChangeDep.changed();
-};
-
-Route.prototype.registerRouteChange = function(currentContext, routeChanging) {
-  // register params
-  var params = currentContext.params;
-  this._updateReactiveDict(this._params, params);
-
-  // register query params
-  var queryParams = currentContext.queryParams;
-  this._updateReactiveDict(this._queryParams, queryParams);
-
-  // if the route is changing, we need to defer triggering path changing
-  // if we did this, old route's path watchers will detect this
-  // Real issue is, above watcher will get removed with the new route
-  // So, we don't need to trigger it now
-  // We are doing it on the route close event. So, if they exists they'll 
-  // get notify that
-  if(!routeChanging) {
+  registerRouteClose() {
+    this._params = new ReactiveDict();
+    this._queryParams = new ReactiveDict();
+    this._routeCloseDep.changed();
     this._pathChangeDep.changed();
   }
-};
 
-Route.prototype._updateReactiveDict = function(dict, newValues) {
-  var currentKeys = _.keys(newValues);
-  var oldKeys = _.keys(dict.keyDeps);
+  registerRouteClose() {
+    this._params = new ReactiveDict();
+    this._queryParams = new ReactiveDict();
+    this._routeCloseDep.changed();
+    this._pathChangeDep.changed();
+  }
 
-  // set new values
-  //  params is an array. So, _.each(params) does not works
-  //  to iterate params
-  _.each(currentKeys, function(key) {
-    dict.set(key, newValues[key]);
-  });
+  registerRouteChange(currentContext, routeChanging) {
+    // register params
+    const params = currentContext.params;
+    this._updateReactiveDict(this._params, params);
 
-  // remove keys which does not exisits here
-  var removedKeys = _.difference(oldKeys, currentKeys);
-  _.each(removedKeys, function(key) {
-    dict.set(key, undefined);
-  });
-};
+    // register query params
+    const queryParams = currentContext.queryParams;
+    this._updateReactiveDict(this._queryParams, queryParams);
+
+    // if the route is changing, we need to defer triggering path changing
+    // if we did this, old route's path watchers will detect this
+    // Real issue is, above watcher will get removed with the new route
+    // So, we don't need to trigger it now
+    // We are doing it on the route close event. So, if they exists they'll 
+    // get notify that
+    if(!routeChanging) {
+      this._pathChangeDep.changed();
+    }
+  }
+
+  _updateReactiveDict(dict, newValues) {
+    const currentKeys = _.keys(newValues);
+    const oldKeys = _.keys(dict.keyDeps);
+
+    // set new values
+    currentKeys.forEach((key) => {
+      dict.set(key, newValues[key]);
+    });
+
+    // remove keys which does not exisits here
+    const removedKeys = _.difference(oldKeys, currentKeys);
+    removedKeys.forEach((key) => {
+      dict.set(key, undefined);
+    });
+  }
+}

--- a/client/router.js
+++ b/client/router.js
@@ -1,262 +1,451 @@
-Router = function () {
-  var self = this;
-  this.globals = [];
-
-  this._current = {};
-
-  // tracks the current path change
-  this._onEveryPath = new Tracker.Dependency();
-
-  this._globalRoute = new Route(this);
-
-  // holds onRoute callbacks
-  this._onRouteCallbacks = [];
-
-  // if _askedToWait is true. We don't automatically start the router
-  // in Meteor.startup callback. (see client/_init.js)
-  // Instead user need to call `.initialize()
-  this._askedToWait = false;
-  this._initialized = false;
-  this._triggersEnter = [];
-  this._triggersExit = [];
-  this._routes = [];
-  this._routesMap = {};
-  this._updateCallbacks();
-  this.notFound = this.notfound = null;
-
-  // Meteor exposes to the client the path prefix that was defined using the
-  // ROOT_URL environement variable on the server using the global runtime
-  // configuration. See #315.
-  this._basePath = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
-
-  // this is a chain contains a list of old routes
-  // most of the time, there is only one old route
-  // but when it's the time for a trigger redirect we've a chain
-  this._oldRouteChain = [];
-
-  this.env = {
-    replaceState: new Meteor.EnvironmentVariable(),
-    reload: new Meteor.EnvironmentVariable(),
-    trailingSlash: new Meteor.EnvironmentVariable()
-  };
-
-  // redirect function used inside triggers
-  this._redirectFn = function(pathDef, fields, queryParams) {
-    if (/^http(s)?:\/\//.test(pathDef)) {
-        var message = "Redirects to URLs outside of the app are not supported in this version of Flow Router. Use 'window.location = yourUrl' instead";
+Router = class {
+  constructor() {
+    this.globals = [];
+  
+    this._current = {};
+  
+    // tracks the current path change
+    this._onEveryPath = new Tracker.Dependency();
+  
+    this._globalRoute = new Route(this);
+  
+    // holds onRoute callbacks
+    this._onRouteCallbacks = [];
+  
+    // if _askedToWait is true. We don't automatically start the router
+    // in Meteor.startup callback. (see client/_init.js)
+    // Instead user need to call `.initialize()
+    this._askedToWait = false;
+    this._initialized = false;
+    this._triggersEnter = [];
+    this._triggersExit = [];
+    this._routes = [];
+    this._routesMap = {};
+    this._updateCallbacks();
+    this.notFound = this.notfound = null;
+  
+    // Meteor exposes to the client the path prefix that was defined using the
+    // ROOT_URL environement variable on the server using the global runtime
+    // configuration. See #315.
+    this._basePath = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+  
+    // this is a chain contains a list of old routes
+    // most of the time, there is only one old route
+    // but when it's the time for a trigger redirect we've a chain
+    this._oldRouteChain = [];
+  
+    this.env = {
+      replaceState: new Meteor.EnvironmentVariable(),
+      reload: new Meteor.EnvironmentVariable(),
+      trailingSlash: new Meteor.EnvironmentVariable()
+    };
+  
+    // redirect function used inside triggers
+    this._redirectFn = (pathDef, fields, queryParams) => {
+      if (/^http(s)?:\/\//.test(pathDef)) {
+        const message = "Redirects to URLs outside of the app are not supported in this version of Flow Router. Use 'window.location = yourUrl' instead";
         throw new Error(message);
-    }
-    self.withReplaceState(function() {
-      var path = FlowRouter.path(pathDef, fields, queryParams);
-      self._page.redirect(path);
-    });
-  };
-  this._initTriggersAPI();
-};
-
-Router.prototype.route = function(pathDef, options, group) {
-  if (!/^\/.*/.test(pathDef)) {
-    var message = "route's path must start with '/'";
-    throw new Error(message);
+      }
+      this.withReplaceState(() => {
+        const path = FlowRouter.path(pathDef, fields, queryParams);
+        this._page.redirect(path);
+      });
+    };
+    this._initTriggersAPI();
   }
+  
+  route(pathDef, options, group) {
+    if (!/^\/.*/.test(pathDef)) {
+      const message = "route's path must start with '/'";
+      throw new Error(message);
+    }
+  
+    options = options || {};
 
-  options = options || {};
-  var self = this;
-  var route = new Route(this, pathDef, options, group);
-
-  // calls when the page route being activates
-  route._actionHandle = function (context, next) {
-    var oldRoute = self._current.route;
-    self._oldRouteChain.push(oldRoute);
-
-    var queryParams = self._qs.parse(context.querystring);
-    // _qs.parse() gives us a object without prototypes,
-    // created with Object.create(null)
-    // Meteor's check doesn't play nice with it.
-    // So, we need to fix it by cloning it.
-    // see more: https://github.com/meteorhacks/flow-router/issues/164
-    queryParams = JSON.parse(JSON.stringify(queryParams));
-
-    self._current = {
+    const route = new Route(this, pathDef, options, group);
+  
+    // calls when the page route being activates
+    route._actionHandle = (context, next) => {
+      const oldRoute = this._current.route;
+      this._oldRouteChain.push(oldRoute);
+  
+      let queryParams = this._qs.parse(context.querystring);
+      // _qs.parse() gives us a object without prototypes,
+      // created with Object.create(null)
+      // Meteor's check doesn't play nice with it.
+      // So, we need to fix it by cloning it.
+      // see more: https://github.com/meteorhacks/flow-router/issues/164
+      queryParams = JSON.parse(JSON.stringify(queryParams));
+  
+      this._current = {
+        path: context.path,
+        context: context,
+        params: context.params,
+        queryParams: queryParams,
+        route: route,
+        oldRoute: oldRoute
+      };
+  
+      // we need to invalidate if all the triggers have been completed
+      // if not that means, we've been redirected to another path
+      // then we don't need to invalidate
+      const afterAllTriggersRan = () => {
+        this._applyRoute();
+      };
+  
+      const triggers = this._triggersEnter.concat(route._triggersEnter);
+      Triggers.runTriggers(
+        triggers,
+        this._current,
+        this._redirectFn,
+        afterAllTriggersRan
+      );
+    };
+  
+    // calls when you exit from the page js route
+    route._exitHandle = (context, next) => {
+      const triggers = this._triggersExit.concat(route._triggersExit);
+      Triggers.runTriggers(
+        triggers,
+        this._current,
+        this._redirectFn,
+        next
+      );
+    };
+  
+    this._routes.push(route);
+    if (options.name) {
+      this._routesMap[options.name] = route;
+    }
+  
+    this._updateCallbacks();
+    this._triggerRouteRegister(route);
+  
+    return route;
+  }
+  
+  group(options) {
+    return new Group(this, options);
+  }
+  
+  path(pathDef, fields, queryParams) {
+    if (this._routesMap[pathDef]) {
+      pathDef = this._routesMap[pathDef].pathDef;
+    }
+  
+    let path = "";
+  
+    // Prefix the path with the router global prefix
+    if (this._basePath) {
+      path += "/" + this._basePath + "/";
+    }
+  
+    fields = fields || {};
+    const regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
+    path += pathDef.replace(regExp, (key) => {
+      let firstRegexpChar = key.indexOf("(");
+      // get the content behind : and (\\d+/)
+      key = key.substring(1, (firstRegexpChar > 0) ? firstRegexpChar : undefined);
+      // remove +?*
+      key = key.replace(/[\+\*\?]+/g, "");
+  
+      // this is to allow page js to keep the custom characters as it is
+      // we need to encode 2 times otherwise "/" char does not work properly
+      // So, in that case, when I includes "/" it will think it's a part of the
+      // route. encoding 2times fixes it
+      return encodeURIComponent(encodeURIComponent(fields[key] || ""));
+    });
+  
+    // Replace multiple slashes with single slash
+    path = path.replace(/\/\/+/g, "/");
+  
+    // remove trailing slash
+    // but keep the root slash if it's the only one
+    path = path.match(/^\/{1}$/) ? path : path.replace(/\/$/, "");
+  
+    // explictly asked to add a trailing slash
+    if (this.env.trailingSlash.get() && _.last(path) !== "/") {
+      path += "/";
+    }
+  
+    const strQueryParams = this._qs.stringify(queryParams || {});
+    if(strQueryParams) {
+      path += "?" + strQueryParams;
+    }
+  
+    return path;
+  }
+  
+  go(pathDef, fields, queryParams) {
+    const path = this.path(pathDef, fields, queryParams);
+  
+    const useReplaceState = this.env.replaceState.get();
+    if(useReplaceState) {
+      this._page.replace(path);
+    } else {
+      this._page(path);
+    }
+  }
+  
+  reload() {
+    this.env.reload.withValue(true, () => {
+      this._page.replace(this._current.path);
+    });
+  }
+  
+  redirect(path) {
+    this._page.redirect(path);
+  }
+  
+  setParams(newParams) {
+    if (!this._current.route) {
+      return false;
+    }
+  
+    const pathDef = this._current.route.pathDef;
+    const existingParams = this._current.params;
+    let params = {};
+    Object.keys(existingParams).forEach((key) => {
+      params[key] = existingParams[key];
+    });
+  
+    // _.extend(dst, src1, src2) can be replaced with Object.assign(dst, src1, src2) in ES2015
+    params = Object.assign(params, newParams);
+    const queryParams = this._current.queryParams;
+  
+    this.go(pathDef, params, queryParams);
+    return true;
+  }
+  
+  setQueryParams(newParams) {
+    if (!this._current.route) {
+      return false;
+    }
+  
+    const queryParams = _.clone(this._current.queryParams);
+    // Object.assign can be used instead of _.extend
+    Object.assign(queryParams, newParams);
+  
+    for (let k in queryParams) {
+      if (queryParams[k] === null || queryParams[k] === undefined) {
+        delete queryParams[k];
+      }
+    }
+  
+    const pathDef = this._current.route.pathDef;
+    const params = this._current.params;
+    this.go(pathDef, params, queryParams);
+    return true;
+  }
+  
+  // .current is not reactive
+  // This is by design. use .getParam() instead
+  // If you really need to watch the path change, use .watchPathChange()
+  current() {
+    // We can't trust outside, that's why we clone this
+    // Anyway, we can't clone the whole object since it has non-jsonable values
+    // That's why we clone what's really needed.
+    const current = _.clone(this._current);
+    current.queryParams = EJSON.clone(current.queryParams);
+    current.params = EJSON.clone(current.params);
+    return current;
+  }
+  
+  withReplaceState(fn) {
+    return this.env.replaceState.withValue(true, fn);
+  }
+  
+  withTrailingSlash(fn) {
+    return this.env.trailingSlash.withValue(true, fn);
+  }
+  
+  _notfoundRoute(context) {
+    this._current = {
       path: context.path,
       context: context,
-      params: context.params,
-      queryParams: queryParams,
-      route: route,
-      oldRoute: oldRoute
+      params: [],
+      queryParams: {},
     };
-
-    // we need to invalidate if all the triggers have been completed
-    // if not that means, we've been redirected to another path
-    // then we don't need to invalidate
-    var afterAllTriggersRan = function() {
-      self._applyRoute();
-    };
-
-    var triggers = self._triggersEnter.concat(route._triggersEnter);
-    Triggers.runTriggers(
-      triggers,
-      self._current,
-      self._redirectFn,
-      afterAllTriggersRan
-    );
-  };
-
-  // calls when you exit from the page js route
-  route._exitHandle = function(context, next) {
-    var triggers = self._triggersExit.concat(route._triggersExit);
-    Triggers.runTriggers(
-      triggers,
-      self._current,
-      self._redirectFn,
-      next
-    );
-  };
-
-  this._routes.push(route);
-  if (options.name) {
-    this._routesMap[options.name] = route;
-  }
-
-  this._updateCallbacks();
-  this._triggerRouteRegister(route);
-
-  return route;
-};
-
-Router.prototype.group = function(options) {
-  return new Group(this, options);
-};
-
-Router.prototype.path = function(pathDef, fields, queryParams) {
-  if (this._routesMap[pathDef]) {
-    pathDef = this._routesMap[pathDef].pathDef;
-  }
-
-  var path = "";
-
-  // Prefix the path with the router global prefix
-  if (this._basePath) {
-    path += "/" + this._basePath + "/";
-  }
-
-  fields = fields || {};
-  var regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
-  path += pathDef.replace(regExp, function(key) {
-    var firstRegexpChar = key.indexOf("(");
-    // get the content behind : and (\\d+/)
-    key = key.substring(1, (firstRegexpChar > 0)? firstRegexpChar: undefined);
-    // remove +?*
-    key = key.replace(/[\+\*\?]+/g, "");
-
-    // this is to allow page js to keep the custom characters as it is
-    // we need to encode 2 times otherwise "/" char does not work properly
-    // So, in that case, when I includes "/" it will think it's a part of the
-    // route. encoding 2times fixes it
-    return encodeURIComponent(encodeURIComponent(fields[key] || ""));
-  });
-
-  // Replace multiple slashes with single slash
-  path = path.replace(/\/\/+/g, "/");
-
-  // remove trailing slash
-  // but keep the root slash if it's the only one
-  path = path.match(/^\/{1}$/) ? path: path.replace(/\/$/, "");
-
-  // explictly asked to add a trailing slash
-  if(this.env.trailingSlash.get() && _.last(path) !== "/") {
-    path += "/";
-  }
-
-  var strQueryParams = this._qs.stringify(queryParams || {});
-  if(strQueryParams) {
-    path += "?" + strQueryParams;
-  }
-
-  return path;
-};
-
-Router.prototype.go = function(pathDef, fields, queryParams) {
-  var path = this.path(pathDef, fields, queryParams);
-
-  var useReplaceState = this.env.replaceState.get();
-  if(useReplaceState) {
-    this._page.replace(path);
-  } else {
-    this._page(path);
-  }
-};
-
-Router.prototype.reload = function() {
-  var self = this;
-
-  self.env.reload.withValue(true, function() {
-    self._page.replace(self._current.path);
-  });
-};
-
-Router.prototype.redirect = function(path) {
-  this._page.redirect(path);
-};
-
-Router.prototype.setParams = function(newParams) {
-  if(!this._current.route) {return false;}
-
-  var pathDef = this._current.route.pathDef;
-  var existingParams = this._current.params;
-  var params = {};
-  _.each(_.keys(existingParams), function(key) {
-    params[key] = existingParams[key];
-  });
-
-  params = _.extend(params, newParams);
-  var queryParams = this._current.queryParams;
-
-  this.go(pathDef, params, queryParams);
-  return true;
-};
-
-Router.prototype.setQueryParams = function(newParams) {
-  if(!this._current.route) {return false;}
-
-  var queryParams = _.clone(this._current.queryParams);
-  _.extend(queryParams, newParams);
-
-  for (var k in queryParams) {
-    if (queryParams[k] === null || queryParams[k] === undefined) {
-      delete queryParams[k];
+  
+    // XXX this.notfound kept for backwards compatibility
+    this.notFound = this.notFound || this.notfound;
+    if (!this.notFound) {
+      console.error("There is no route for the path:", context.path);
+      return;
     }
+  
+    this._current.route = new Route(this, "*", this.notFound);
+    this._applyRoute();
   }
-
-  var pathDef = this._current.route.pathDef;
-  var params = this._current.params;
-  this.go(pathDef, params, queryParams);
-  return true;
-};
-
-// .current is not reactive
-// This is by design. use .getParam() instead
-// If you really need to watch the path change, use .watchPathChange()
-Router.prototype.current = function() {
-  // We can't trust outside, that's why we clone this
-  // Anyway, we can't clone the whole object since it has non-jsonable values
-  // That's why we clone what's really needed.
-  var current = _.clone(this._current);
-  current.queryParams = EJSON.clone(current.queryParams);
-  current.params = EJSON.clone(current.params);
-  return current;
-};
+  
+  initialize(options) {
+    options = options || {};
+  
+    if (this._initialized) {
+      throw new Error("FlowRouter is already initialized");
+    }
+  
+    this._updateCallbacks();
+  
+    // Implementing idempotent routing
+    // by overriding page.js`s "show" method.
+    // Why?
+    // It is impossible to bypass exit triggers,
+    // because they execute before the handler and
+    // can not know what the next path is, inside exit trigger.
+    //
+    // we need override both show, replace to make this work
+    // since we use redirect when we are talking about withReplaceState
+    ['show', 'replace'].forEach((fnName) => {
+      const original = this._page[fnName];
+      this._page[fnName] = (path, state, dispatch, push) => {
+        const reload = this.env.reload.get();
+        if (!reload && this._current.path === path) {
+          return;
+        }
+  
+        original.call(this, path, state, dispatch, push);
+      };
+    });
+  
+    // this is very ugly part of pagejs and it does decoding few times
+    // in unpredicatable manner. See #168
+    // this is the defa_ult behaviour and we need keep it like that
+    // we are doing a hack. see .path()
+    this._page.base(this._basePath);
+    this._page({
+      decodeURLComponents: true,
+      hashbang: !!options.hashbang
+    });
+  
+    this._initialized = true;
+  }
+  
+  _applyRoute() {
+    // see the definition of `this._processingContexts`
+    const currentContext = this._current;
+    const route = currentContext.route;
+    const path = currentContext.path;
+  
+    // otherwise, computations inside action will trigger to re-run
+    // this computation. which we do not need.
+    Tracker.nonreactive(() => {
+      let isRouteChange = currentContext.oldRoute !== currentContext.route;
+      const isFirstRoute = !currentContext.oldRoute;
+      // first route is not a route change
+      if(isFirstRoute) {
+        isRouteChange = false;
+      }
+  
+      // Clear oldRouteChain just before calling the action
+      // We still need to get a copy of the oldestRoute first
+      // It's very important to get the oldest route and registerRouteClose() it
+      // See: https://github.com/kadirahq/flow-router/issues/314
+      const oldestRoute = this._oldRouteChain[0];
+      this._oldRouteChain = [];
+  
+      currentContext.route.registerRouteChange(currentContext, isRouteChange);
+      route.callAction(currentContext);
+  
+      Tracker.afterFlush(() => {
+        this._onEveryPath.changed();
+        if (isRouteChange) {
+          // We need to trigger that route (definition itself) has changed.
+          // So, we need to re-run all the register callbacks to current route
+          // This is pretty important, otherwise tracker
+          // can't identify new route's items
+  
+          // We also need to afterFlush, otherwise this will re-run
+          // helpers on templates which are marked for destroying
+          if (oldestRoute) {
+            oldestRoute.registerRouteClose();
+          }
+        }
+      });
+    });
+  }
+  
+  _updateCallbacks() {
+    this._page.callbacks = [];
+    this._page.exits = [];
+  
+    this._routes.forEach((route) => {
+      this._page(route.pathDef, route._actionHandle);
+      this._page.exit(route.pathDef, (context, next) => {
+        // XXX: With React, exit handler gets called twice
+        // We've not debugged into why yet, but it's an issue
+        // so, we need to manually handle it like this
+        if (this._oldExitPath === context.path) {
+          return next();
+        }
+  
+        this._oldExitPath = context.path;
+        route._exitHandle(context, next);
+      });
+    });
+  
+    this._page("*", (context) => {
+      this._notfoundRoute(context);
+    });
+  }
+  
+  _initTriggersAPI() {
+    this.triggers = {
+      enter: (triggers, filter) => {
+        triggers = Triggers.applyFilters(triggers, filter);
+        if (triggers.length) {
+          this._triggersEnter = this._triggersEnter.concat(triggers);
+        }
+      },
+  
+      exit: (triggers, filter) => {
+        triggers = Triggers.applyFilters(triggers, filter);
+        if (triggers.length) {
+          this._triggersExit = this._triggersExit.concat(triggers);
+        }
+      }
+    };
+  }
+  
+  wait() {
+    if (this._initialized) {
+      throw new Error("can't wait after FlowRouter has been initialized");
+    }
+  
+    this._askedToWait = true;
+  }
+  
+  onRouteRegister(cb) {
+    this._onRouteCallbacks.push(cb);
+  }
+  
+  _triggerRouteRegister(currentRoute) {
+    // We should only need to send a safe set of fields on the route
+    // object.
+    // This is not to hide what's inside the route object, but to show
+    // these are the public APIs
+    const routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
+    const omittingOptionFields = [
+      'triggersEnter', 'triggersExit', 'action', 'name'
+    ];
+    routePublicApi.options = _.omit(currentRoute.options, omittingOptionFields);
+  
+    this._onRouteCallbacks.forEach((cb) => {
+      cb(routePublicApi);
+    });
+  }
+}
 
 // Implementing Reactive APIs
-var reactiveApis = [
+const reactiveApis = [
   'getParam', 'getQueryParam',
   'getRouteName', 'watchPathChange'
 ];
-reactiveApis.forEach(function(api) {
-  Router.prototype[api] = function(arg1) {
+reactiveApis.forEach((api) => {
+  Router.prototype[api] = function (arg1) {
     // when this is calling, there may not be any route initiated
     // so we need to handle it
-    var currentRoute = this._current.route;
+    const currentRoute = this._current.route;
     if(!currentRoute) {
       this._onEveryPath.depend();
       return;
@@ -267,196 +456,6 @@ reactiveApis.forEach(function(api) {
     return currentRoute[api].call(currentRoute, arg1);
   };
 });
-
-Router.prototype.withReplaceState = function(fn) {
-  return this.env.replaceState.withValue(true, fn);
-};
-
-Router.prototype.withTrailingSlash = function(fn) {
-  return this.env.trailingSlash.withValue(true, fn);
-};
-
-Router.prototype._notfoundRoute = function(context) {
-  this._current = {
-    path: context.path,
-    context: context,
-    params: [],
-    queryParams: {},
-  };
-
-  // XXX this.notfound kept for backwards compatibility
-  this.notFound = this.notFound || this.notfound;
-  if(!this.notFound) {
-    console.error("There is no route for the path:", context.path);
-    return;
-  }
-
-  this._current.route = new Route(this, "*", this.notFound);
-  this._applyRoute();
-};
-
-Router.prototype.initialize = function(options) {
-  options = options || {};
-
-  if(this._initialized) {
-    throw new Error("FlowRouter is already initialized");
-  }
-
-  var self = this;
-  this._updateCallbacks();
-
-  // Implementing idempotent routing
-  // by overriding page.js`s "show" method.
-  // Why?
-  // It is impossible to bypass exit triggers,
-  // because they execute before the handler and
-  // can not know what the next path is, inside exit trigger.
-  //
-  // we need override both show, replace to make this work
-  // since we use redirect when we are talking about withReplaceState
-  _.each(['show', 'replace'], function(fnName) {
-    var original = self._page[fnName];
-    self._page[fnName] = function(path, state, dispatch, push) {
-      var reload = self.env.reload.get();
-      if (!reload && self._current.path === path) {
-        return;
-      }
-
-      original.call(this, path, state, dispatch, push);
-    };
-  });
-
-  // this is very ugly part of pagejs and it does decoding few times
-  // in unpredicatable manner. See #168
-  // this is the defa_ult behaviour and we need keep it like that
-  // we are doing a hack. see .path()
-  this._page.base(this._basePath);
-  this._page({
-    decodeURLComponents: true,
-    hashbang: !!options.hashbang
-  });
-
-  this._initialized = true;
-};
-
-Router.prototype._applyRoute = function() {
-  var self = this;
-
-  // see the definition of `this._processingContexts`
-  var currentContext = self._current;
-  var route = currentContext.route;
-  var path = currentContext.path;
-
-  // otherwise, computations inside action will trigger to re-run
-  // this computation. which we do not need.
-  Tracker.nonreactive(function() {
-    var isRouteChange = currentContext.oldRoute !== currentContext.route;
-    var isFirstRoute = !currentContext.oldRoute;
-    // first route is not a route change
-    if(isFirstRoute) {
-      isRouteChange = false;
-    }
-
-    // Clear oldRouteChain just before calling the action
-    // We still need to get a copy of the oldestRoute first
-    // It's very important to get the oldest route and registerRouteClose() it
-    // See: https://github.com/kadirahq/flow-router/issues/314
-    var oldestRoute = self._oldRouteChain[0];
-    self._oldRouteChain = [];
-
-    currentContext.route.registerRouteChange(currentContext, isRouteChange);
-    route.callAction(currentContext);
-
-    Tracker.afterFlush(function() {
-      self._onEveryPath.changed();
-      if(isRouteChange) {
-        // We need to trigger that route (definition itself) has changed.
-        // So, we need to re-run all the register callbacks to current route
-        // This is pretty important, otherwise tracker
-        // can't identify new route's items
-
-        // We also need to afterFlush, otherwise this will re-run
-        // helpers on templates which are marked for destroying
-        if(oldestRoute) {
-          oldestRoute.registerRouteClose();
-        }
-      }
-    });
-  });
-};
-
-Router.prototype._updateCallbacks = function () {
-  var self = this;
-
-  self._page.callbacks = [];
-  self._page.exits = [];
-
-  _.each(self._routes, function(route) {
-    self._page(route.pathDef, route._actionHandle);
-    self._page.exit(route.pathDef, function(context, next) {
-      // XXX: With React, exit handler gets called twice
-      // We've not debugged into why yet, but it's an issue
-      // so, we need to manually handle it like this
-      if(self._oldExitPath === context.path) {
-        return next();
-      }
-
-      self._oldExitPath = context.path;
-      route._exitHandle(context, next);
-    });
-  });
-
-  self._page("*", function(context) {
-    self._notfoundRoute(context);
-  });
-};
-
-Router.prototype._initTriggersAPI = function() {
-  var self = this;
-  this.triggers = {
-    enter: function(triggers, filter) {
-      triggers = Triggers.applyFilters(triggers, filter);
-      if(triggers.length) {
-        self._triggersEnter = self._triggersEnter.concat(triggers);
-      }
-    },
-
-    exit: function(triggers, filter) {
-      triggers = Triggers.applyFilters(triggers, filter);
-      if(triggers.length) {
-        self._triggersExit = self._triggersExit.concat(triggers);
-      }
-    }
-  };
-};
-
-Router.prototype.wait = function() {
-  if(this._initialized) {
-    throw new Error("can't wait after FlowRouter has been initialized");
-  }
-
-  this._askedToWait = true;
-};
-
-Router.prototype.onRouteRegister = function(cb) {
-  this._onRouteCallbacks.push(cb);
-};
-
-Router.prototype._triggerRouteRegister = function(currentRoute) {
-  // We should only need to send a safe set of fields on the route
-  // object.
-  // This is not to hide what's inside the route object, but to show
-  // these are the public APIs
-  var routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
-  var omittingOptionFields = [
-    'triggersEnter', 'triggersExit', 'action', 'name'
-  ];
-  routePublicApi.options = _.omit(currentRoute.options, omittingOptionFields);
-
-  _.each(this._onRouteCallbacks, function(cb) {
-    cb(routePublicApi);
-  });
-};
 
 Router.prototype._page = page;
 Router.prototype._qs = qs;

--- a/client/triggers.js
+++ b/client/triggers.js
@@ -6,7 +6,7 @@ Triggers = {};
 // @triggers - a set of triggers
 // @filter - filter with array fileds with `only` and `except` 
 //           support only either `only` or `except`, but not both
-Triggers.applyFilters = function(triggers, filter) {
+Triggers.applyFilters = (triggers, filter) => {
   if(!(triggers instanceof Array)) {
     triggers = [triggers];
   }
@@ -42,19 +42,20 @@ Triggers.applyFilters = function(triggers, filter) {
 //  @triggers - a set of triggers 
 //  @names - list of route names to be bound (trigger runs only for these names)
 //  @negate - negate the result (triggers won't run for above names)
-Triggers.createRouteBoundTriggers = function(triggers, names, negate) {
-  var namesMap = {};
-  _.each(names, function(name) {
+Triggers.createRouteBoundTriggers = (triggers, names, negate) => {
+  const namesMap = {};
+
+  names.forEach((name) => {
     namesMap[name] = true;
   });
 
-  var filteredTriggers = _.map(triggers, function(originalTrigger) {
-    var modifiedTrigger = function(context, next) {
-      var routeName = context.route.name;
-      var matched = (namesMap[routeName])? 1: -1;
-      matched = (negate)? matched * -1 : matched;
+  const filteredTriggers = triggers.map((originalTrigger) => {
+    const modifiedTrigger = (context, next) => {
+      const routeName = context.route.name;
+      let matched = (namesMap[routeName]) ? 1: -1;
+      matched = (negate) ? matched * -1 : matched;
 
-      if(matched === 1) {
+      if (matched === 1) {
         originalTrigger(context, next);
       }
     };
@@ -69,16 +70,16 @@ Triggers.createRouteBoundTriggers = function(triggers, names, negate) {
 //  @context - context we need to pass (it must have the route)
 //  @redirectFn - function which used to redirect 
 //  @after - called after if only all the triggers runs
-Triggers.runTriggers = function(triggers, context, redirectFn, after) {
-  var abort = false;
-  var inCurrentLoop = true;
-  var alreadyRedirected = false;
+Triggers.runTriggers = (triggers, context, redirectFn, after) => {
+  let abort = false;
+  let inCurrentLoop = true;
+  let alreadyRedirected = false;
 
-  for(var lc=0; lc<triggers.length; lc++) {
-    var trigger = triggers[lc];
+  for (let lc=0; lc<triggers.length; lc++) {
+    const trigger = triggers[lc];
     trigger(context, doRedirect, doStop);
 
-    if(abort) {
+    if (abort) {
       return;
     }
   }
@@ -89,15 +90,15 @@ Triggers.runTriggers = function(triggers, context, redirectFn, after) {
   after();
 
   function doRedirect(url, params, queryParams) {
-    if(alreadyRedirected) {
+    if (alreadyRedirected) {
       throw new Error("already redirected");
     }
 
-    if(!inCurrentLoop) {
+    if (!inCurrentLoop) {
       throw new Error("redirect needs to be done in sync");
     }
 
-    if(!url) {
+    if (!url) {
       throw new Error("trigger redirect requires an URL");
     }
 

--- a/package.js
+++ b/package.js
@@ -52,8 +52,9 @@ Package.onTest(function(api) {
 });
 
 function configure(api) {
-  api.versionsFrom('1.0');
+  api.versionsFrom('1.2');
 
+  api.use('ecmascript');
   api.use('underscore');
   api.use('tracker');
   api.use('reactive-dict');

--- a/server/group.js
+++ b/server/group.js
@@ -1,18 +1,20 @@
-Group = function(router, options) {
-  options = options || {};
-  this.prefix = options.prefix || '';
-  this.options = options;
-  this._router = router;
-};
+Group = class {
+  constructor(router, options) {
+    options = options || {};
+    this.prefix = options.prefix || '';
+    this.options = options;
+    this._router = router;
+  }
 
-Group.prototype.route = function(pathDef, options) {
-  pathDef = this.prefix + pathDef;
-  return this._router.route(pathDef, options);
-};
-
-Group.prototype.group = function(options) {
-  var group = new Group(this._router, options);
-  group.parent = this;
-
-  return group;
-};
+  route(pathDef, options) {
+    pathDef = this.prefix + pathDef;
+    return this._router.route(pathDef, options);
+  }
+  
+  group(options) {
+    const group = new Group(this._router, options);
+    group.parent = this;
+  
+    return group;
+  }
+}

--- a/server/plugins/fast_render.js
+++ b/server/plugins/fast_render.js
@@ -1,36 +1,34 @@
-if(!Package['meteorhacks:fast-render']) {
+if (!Package['meteorhacks:fast-render']) {
   return;
 }
 
 FastRender = Package['meteorhacks:fast-render'].FastRender;
 
 // hack to run after eveything else on startup
-Meteor.startup(function () {
-  Meteor.startup(function () {
+Meteor.startup(() => {
+  Meteor.startup(() => {
     setupFastRender();
   });
 });
 
 function setupFastRender () {
-  _.each(FlowRouter._routes, function (route) {
-    FastRender.route(route.pathDef, function (routeParams, path) {
-      var self = this;
-
+  FlowRouter._routes.forEach((route) => {
+    FastRender.route(route.pathDef, (routeParams, path) => {
       // anyone using Meteor.subscribe for something else?
-      var original = Meteor.subscribe;
-      Meteor.subscribe = function () {
-        return _.toArray(arguments);
+      const original = Meteor.subscribe;
+      Meteor.subscribe = (...args) => {
+        return _.toArray(args);
       };
 
       route._subsMap = {};
       FlowRouter.subscriptions.call(route, path);
-      if(route.subscriptions) {
-        var queryParams = routeParams.query;
-        var params = _.omit(routeParams, 'query');
+      if (route.subscriptions) {
+        const queryParams = routeParams.query;
+        const params = _.omit(routeParams, 'query');
         route.subscriptions(params, queryParams);
       }
-      _.each(route._subsMap, function (args) {
-        self.subscribe.apply(self, args);
+      route._subsMap.forEach((args) => {
+        this.subscribe.apply(this, args);
       });
 
       // restore Meteor.subscribe, ... on server side

--- a/server/plugins/ssr_data.js
+++ b/server/plugins/ssr_data.js
@@ -1,47 +1,53 @@
-var originalSubscribe = Meteor.subscribe;
-Meteor.subscribe = function(pubName) {
-  var params = Array.prototype.slice.call(arguments, 1);
+const originalSubscribe = Meteor.subscribe;
 
-  var ssrContext = FlowRouter.ssrContext.get();
-  if(ssrContext) {
-    FlowRouter.inSubscription.withValue(true, function() {
+Meteor.subscribe = function (pubName) {
+  const params = Array.prototype.slice.call(arguments, 1);
+
+  const ssrContext = FlowRouter.ssrContext.get();
+  if (ssrContext) {
+    FlowRouter.inSubscription.withValue(true, () => {
       ssrContext.addSubscription(pubName, params);
     });
   }
 
-  if(originalSubscribe) {
+  if (originalSubscribe) {
     originalSubscribe.apply(this, arguments);
   }
-  return {ready: function () {return true}};
+  
+  return {
+    ready: () => true
+  };
 };
 
-var Mongo = Package['mongo'].Mongo;
-var originalFind = Mongo.Collection.prototype.find;
-Mongo.Collection.prototype.find = function(selector, options) {
+const Mongo = Package['mongo'].Mongo;
+const originalFind = Mongo.Collection.prototype.find;
+
+Mongo.Collection.prototype.find = function (selector, options) {
   selector = selector || {};
-  var collName = this._name;
-  var ssrContext = FlowRouter.ssrContext.get();
-  if(ssrContext && !FlowRouter.inSubscription.get()) {
-    var collection = ssrContext.getCollection(collName);
-    var cursor = collection.find(selector, options);
+  const collName = this._name;
+  const ssrContext = FlowRouter.ssrContext.get();
+  if (ssrContext && !FlowRouter.inSubscription.get()) {
+    const collection = ssrContext.getCollection(collName);
+    const cursor = collection.find(selector, options);
     return cursor;
   }
 
   return originalFind.call(this, selector, options);
 };
 
-Mongo.Collection.prototype.findOne = function(selector, options) {
+Mongo.Collection.prototype.findOne = function (selector, options) {
   options = options || {};
   options.limit = 1;
   return this.find(selector, options).fetch()[0];
 };
 
-var originalAutorun = Tracker.autorun;
-Tracker.autorun = function (fn) {
+const originalAutorun = Tracker.autorun;
+
+Tracker.autorun = (fn) => {
   // if autorun is in the ssrContext, we need fake and run the callback 
   // in the same eventloop
-  if(FlowRouter.ssrContext.get()) {
-    var c = {firstRun: true, stop: function () {}};
+  if (FlowRouter.ssrContext.get()) {
+    const c = { firstRun: true, stop: () => {} };
     fn(c);
     return c;
   } else {
@@ -52,13 +58,11 @@ Tracker.autorun = function (fn) {
 // By default, Meteor[call,apply] also inherit SsrContext
 // So, they can't access the full MongoDB dataset because of that
 // Then, we need to remove the SsrContext within Method calls
-['call', 'apply'].forEach(function(methodName) {
-  var original = Meteor[methodName];
-  Meteor[methodName] = function() {
-    var self = this;
-    var args = arguments;
-    var response = FlowRouter.ssrContext.withValue(null, function() {
-      return original.apply(self, args);
+['call', 'apply'].forEach((methodName) => {
+  const original = Meteor[methodName];
+  Meteor[methodName] = (...args) => {
+    const response = FlowRouter.ssrContext.withValue(null, () => {
+      return original.apply(this, args);
     });
 
     return response;
@@ -67,6 +71,6 @@ Tracker.autorun = function (fn) {
 
 // This is not available in the server. But to make it work with SSR
 // We need to have it.
-Meteor.loggingIn = function() {
+Meteor.loggingIn = () => {
   return false;
 };

--- a/server/route.js
+++ b/server/route.js
@@ -1,195 +1,178 @@
-var Url = Npm.require('url');
-var Cheerio = Npm.require('cheerio');
+const Url = Npm.require('url');
+const Cheerio = Npm.require('cheerio');
 
-Route = function(router, pathDef, options) {
-  var self = this;
-  options = options || {};
-  this.options = options;
-  this.name = options.name;
-  this.pathDef = pathDef;
-
-
-  // Route.path is deprecated and will be removed in 3.0
-  this.path = this.pathDef;
-
-  this.action = options.action || Function.prototype;
-  this._router = router;
-  this.subscriptions = options.subscriptions || Function.prototype;
-  this._subsMap = {};
-  this._cache = {};
-
-  Picker.middleware(Npm.require('connect').cookieParser());
-  // process null subscriptions with FR support
-  Picker.middleware(FastRender.handleOnAllRoutes);
+Route = class {
+  constructor(router, pathDef, options) {
+    options = options || {};
+    this.options = options;
+    this.name = options.name;
+    this.pathDef = pathDef;
   
-  var route = FlowRouter.basePath + this.pathDef;
-  Picker.route(route, function(params, req, res, next) {
-
-    if(!self.isHtmlPage(req.url)) {
-      return next();
-    }
-
-    var cachedPage = self._lookupCachedPage(req.url);
-    if(cachedPage) {
-      return self._processFromCache(cachedPage, res, next);
-    }
-
-    var processFromSsr = self._processFromSsr.bind(self, params, req, res);
-    FastRender.handleRoute(processFromSsr, params, req, res, function(data) {
-      next();
-    }); 
-  });
-};
-
-Route.prototype._processFromSsr = function (params, req, res) {
-  var self = this;
-  var ssrContext = new SsrContext();
-  self._router.ssrContext.withValue(ssrContext, function() {
-    var queryParams = params.query;
-    // We need to remove `.query` since it's not part of our params API
-    // But we only need to remove it in our copy. 
-    // We should not trigger any side effects
-    params = _.clone(params);
-    delete params.query;
-    var context = self._buildContext(req.url, params, queryParams);
-
-    self._router.currentRoute.withValue(context, function () {
-      try {
-        // get the data for null subscriptions and add them to the
-        // ssrContext
-        var frData = res.getData("fast-render-data");
-        if(frData) {
-          ssrContext.addData(frData.collectionData);
-        }
-
-        if(self.options.subscriptions) {
-          self.options.subscriptions.call(self, params, queryParams);
-        }
-
-        if(self.options.action) {
-          self.options.action.call(self, params, queryParams);
-        }
-      } catch(ex) {
-        console.error("Error when doing SSR. path:", req.url, " ", ex.message);
-        console.error(ex.stack);
+  
+    // Route.path is deprecated and will be removed in 3.0
+    this.path = this.pathDef;
+  
+    this.action = options.action || Function.prototype;
+    this._router = router;
+    this._cache = {};
+  
+    Picker.middleware(Npm.require('connect').cookieParser());
+    // process null subscriptions with FR support
+    Picker.middleware(FastRender.handleOnAllRoutes);
+    
+    const route = FlowRouter.basePath + this.pathDef;
+    Picker.route(route, (params, req, res, next) => {
+  
+      if (!this.isHtmlPage(req.url)) {
+        return next();
       }
+  
+      const cachedPage = this._lookupCachedPage(req.url);
+      if (cachedPage) {
+        return this._processFromCache(cachedPage, res, next);
+      }
+  
+      const processFromSsr = this._processFromSsr.bind(this, params, req, res);
+      FastRender.handleRoute(processFromSsr, params, req, res, (data) => {
+        next();
+      }); 
     });
-
-    var originalWrite = res.write;
-    res.write = function(data) {
-      if(typeof data === 'string') {
-        var head = ssrContext.getHead();
-        if(head && head.trim() !== "") {
-          data = data.replace('</head>', head + '\n</head>');
+  }
+  
+  _processFromSsr(params, req, res) {
+    const self = this;
+    const ssrContext = new SsrContext();
+    
+    self._router.ssrContext.withValue(ssrContext, function () {
+      const queryParams = params.query;
+      // We need to remove `.query` since it's not part of our params API
+      // But we only need to remove it in our copy. 
+      // We should not trigger any side effects
+      params = _.clone(params);
+      delete params.query;
+      const context = self._buildContext(req.url, params, queryParams);
+  
+      self._router.currentRoute.withValue(context, () => {
+        try {
+          // get the data for null subscriptions and add them to the
+          // ssrContext
+          const frData = res.getData("fast-render-data");
+          if(frData) {
+            ssrContext.addData(frData.collectionData);
+          }
+  
+          if(self.options.action) {
+            self.options.action.call(self, params, queryParams);
+          }
+        } catch(ex) {
+          console.error("Error when doing SSR. path:", req.url, " ", ex.message);
+          console.error(ex.stack);
         }
-
-        var reactRoot = ssrContext.getHtml();
-        if (self._router.deferScriptLoading) {
-          data = moveScripts(data);
+      });
+  
+      const originalWrite = res.write;
+      res.write = function (data) {
+        if(typeof data === 'string') {
+          const head = ssrContext.getHead();
+          if(head && head.trim() !== "") {
+            data = data.replace('</head>', head + '\n</head>');
+          }
+  
+          const reactRoot = ssrContext.getHtml();
+          if (self._router.deferScriptLoading) {
+            data = moveScripts(data);
+          }
+          data = data.replace('<body>', '<body>' + reactRoot);
+  
+          const pageInfo = {
+            frData: res.getData("fast-render-data"),
+            html: data
+          };
+  
+          // cache the page if mentioned a timeout
+          if(self._router.pageCacheTimeout) {
+            self._cachePage(req.url, pageInfo, self._router.pageCacheTimeout);
+          }
         }
-        data = data.replace('<body>', '<body>' + reactRoot);
-
-        var pageInfo = {
-          frData: res.getData("fast-render-data"),
-          html: data
-        };
-
-        // cache the page if mentioned a timeout
-        if(self._router.pageCacheTimeout) {
-          self._cachePage(req.url, pageInfo, self._router.pageCacheTimeout);
-        }
-      }
-      
-      originalWrite.call(this, data);
+        
+        originalWrite.call(this, data);
+      };
+    });
+  
+    function moveScripts(data) {
+      const $ = Cheerio.load(data, {
+        decodeEntities: false
+      });
+      const heads = $('head script');
+      $('body').append(heads);
+  
+      // Remove empty lines caused by removing scripts
+      $('head').html($('head').html().replace(/(^[ \t]*\n)/gm, ''));
+  
+      return $.html();
+    }
+  }
+  
+  _processFromCache(pageInfo, res, next) {
+    const originalWrite = res.write;
+    res.write = function (data) {
+      originalWrite.call(this, pageInfo.html);
+    }
+  
+    res.pushData('fast-render-data', pageInfo.frData);
+    next();
+  }
+  
+  _buildContext(url, params, queryParams) {
+    const context = {
+      route: this,
+      path: url,
+      params: params,
+      queryParams: queryParams
     };
-  });
-
-  function moveScripts(data) {
-    var $ = Cheerio.load(data, {
-      decodeEntities: false
-    });
-    var heads = $('head script');
-    $('body').append(heads);
-
-    // Remove empty lines caused by removing scripts
-    $('head').html($('head').html().replace(/(^[ \t]*\n)/gm, ''));
-
-    return $.html();
+  
+    return context;
   }
-};
-
-Route.prototype._processFromCache = function(pageInfo, res, next) {
-  var originalWrite = res.write;
-  res.write = function(data) {
-    originalWrite.call(this, pageInfo.html);
+  
+  isHtmlPage(url) {
+    const pathname = Url.parse(url).pathname;
+    const ext = pathname.split('.').slice(1).join('.');
+  
+    // if there is no extention, yes that's a html page
+    if(!ext) {
+      return true;
+    }
+  
+    // if this is htm or html, yes that's a html page
+    if(/^htm/.test(ext)) {
+      return true;
+    }
+  
+    // if not we assume this is not as a html page
+    // this doesn't do any harm. But no SSR
+    return false;
   }
-
-  res.pushData('fast-render-data', pageInfo.frData);
-  next();
-};
-
-Route.prototype._buildContext = function(url, params, queryParams) {
-  var context = {
-    route: this,
-    path: url,
-    params: params,
-    queryParams: queryParams
-  };
-
-  return context;
-};
-
-Route.prototype.isHtmlPage = function(url) {
-  var pathname = Url.parse(url).pathname;
-  var ext = pathname.split('.').slice(1).join('.');
-
-  // if there is no extention, yes that's a html page
-  if(!ext) {
-    return true;
+  
+  _lookupCachedPage(url) {
+    const info = this._cache[url];
+    if(info) {
+      return info.data;
+    }
   }
-
-  // if this is htm or html, yes that's a html page
-  if(/^htm/.test(ext)) {
-    return true;
+  
+  _cachePage(url, data, timeout) {
+    const existingInfo = this._cache[url];
+    if(existingInfo) {
+      clearTimeout(existingInfo.timeoutHandle);
+    }
+  
+    const info = {
+      data: data,
+      timeoutHandle: setTimeout(() => {
+        delete this._cache[url];
+      }, timeout)
+    };
+  
+    this._cache[url] = info;
   }
-
-  // if not we assume this is not as a html page
-  // this doesn't do any harm. But no SSR
-  return false;
-};
-
-Route.prototype._lookupCachedPage= function(url) {
-  var info = this._cache[url];
-  if(info) {
-    return info.data;
-  }
-};
-
-Route.prototype._cachePage = function(url, data, timeout) {
-  var self = this;
-  var existingInfo = this._cache[url];
-  if(existingInfo) {
-    clearTimeout(existingInfo.timeoutHandle);
-  }
-
-  var info = {
-    data: data,
-    timeoutHandle: setTimeout(function() {
-      delete self._cache[url];
-    }, timeout)
-  };
-
-  this._cache[url] = info;
-};
-
-Route.prototype.register = function(name, sub, options) {
-  this._subsMap[name] = sub;
-};
-
-Route.prototype.subscription = function(name) {
-  return this._subsMap[name];
-};
-
-Route.prototype.middleware = function(middleware) {
-
-};
+}

--- a/server/router.js
+++ b/server/router.js
@@ -1,133 +1,150 @@
-var Qs = Npm.require('qs');
+const Qs = Npm.require('qs');
 
-Router = function () {
-  this._routes = [];
-  this._routesMap = {};
-  this.subscriptions = Function.prototype;
-  this.ssrContext = new Meteor.EnvironmentVariable();
-  this.inSubscription = new Meteor.EnvironmentVariable();
-  this.currentRoute = new Meteor.EnvironmentVariable();
-  this.pageCacheTimeout = 1000 * 30;
-
-  // holds onRoute callbacks
-  this._onRouteCallbacks = [];
-};
-
-Router.prototype.route = function(pathDef, options) {
-  if (!/^\/.*/.test(pathDef)) {
-    var message = "route's path must start with '/'";
-    throw new Error(message);
+Router = class {
+  constructor() {
+    this._routes = [];
+    this._routesMap = {};
+    this.subscriptions = Function.prototype;
+    this.ssrContext = new Meteor.EnvironmentVariable();
+    this.inSubscription = new Meteor.EnvironmentVariable();
+    this.currentRoute = new Meteor.EnvironmentVariable();
+    this.pageCacheTimeout = 1000 * 30;
+  
+    // holds onRoute callbacks
+    this._onRouteCallbacks = [];
   }
   
-  options = options || {};
-  var route = new Route(this, pathDef, options);
-  this._routes.push(route);
-
-  if (options.name) {
-    this._routesMap[options.name] = route;
+  route(pathDef, options) {
+    if (!/^\/.*/.test(pathDef)) {
+      const message = "route's path must start with '/'";
+      throw new Error(message);
+    }
+    
+    options = options || {};
+    const route = new Route(this, pathDef, options);
+    this._routes.push(route);
+  
+    if (options.name) {
+      this._routesMap[options.name] = route;
+    }
+  
+    this._triggerRouteRegister(route);
+    
+    return route;
   }
-
-  this._triggerRouteRegister(route);
-  return route;
-};
-
-Router.prototype.group = function(options) {
-  return new Group(this, options);
-};
-
-Router.prototype.path = function(pathDef, fields, queryParams) {
-  if(this._routesMap[pathDef]) {
-    pathDef = this._routesMap[pathDef].path;
+  
+  group(options) {
+    return new Group(this, options);
   }
-
-  var path = FlowRouter.basePath;
-
-  fields = fields || {};
-  var regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
-  path += pathDef.replace(regExp, function(key) {
-    var firstRegexpChar = key.indexOf("(");
-    // get the content behind : and (\\d+/)
-    key = key.substring(1, (firstRegexpChar > 0)? firstRegexpChar: undefined);
-    // remove +?*
-    key = key.replace(/[\+\*\?]+/g, "");
-
-    return fields[key] || "";
-  });
-
-  path = path.replace(/\/\/+/g, "/"); // Replace multiple slashes with single slash
-
-  // remove trailing slash
-  // but keep the root slash if it's the only one
-  path = path.match(/^\/{1}$/) ? path: path.replace(/\/$/, "");
-
-  var strQueryParams = Qs.stringify(queryParams || {});
-  if(strQueryParams) {
-    path += "?" + strQueryParams;
+  
+  path(pathDef, fields, queryParams) {
+    if(this._routesMap[pathDef]) {
+      pathDef = this._routesMap[pathDef].path;
+    }
+  
+    let path = FlowRouter.basePath;
+  
+    fields = fields || {};
+    const regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
+    path += pathDef.replace(regExp, function(key) {
+      const firstRegexpChar = key.indexOf("(");
+      // get the content behind : and (\\d+/)
+      key = key.substring(1, (firstRegexpChar > 0) ? firstRegexpChar : undefined);
+      // remove +?*
+      key = key.replace(/[\+\*\?]+/g, "");
+  
+      return fields[key] || "";
+    });
+  
+    path = path.replace(/\/\/+/g, "/"); // Replace multiple slashes with single slash
+  
+    // remove trailing slash
+    // but keep the root slash if it's the only one
+    path = path.match(/^\/{1}$/) ? path: path.replace(/\/$/, "");
+  
+    const strQueryParams = Qs.stringify(queryParams || {});
+    if(strQueryParams) {
+      path += "?" + strQueryParams;
+    }
+  
+    return path;
   }
-
-  return path;
-};
-
-Router.prototype.onRouteRegister = function(cb) {
-  this._onRouteCallbacks.push(cb);
-};
-
-Router.prototype._triggerRouteRegister = function(currentRoute) {
-  // We should only need to send a safe set of fields on the route
-  // object.
-  // This is not to hide what's inside the route object, but to show 
-  // these are the public APIs
-  var routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
-  var omittingOptionFields = [
-    'triggersEnter', 'triggersExit', 'action', 'subscriptions', 'name'
-  ];
-  routePublicApi.options = _.omit(currentRoute.options, omittingOptionFields);
-
-  _.each(this._onRouteCallbacks, function(cb) {
-    cb(routePublicApi);
-  });
-};
-
-Router.prototype.url = function() {
-  var path = this.path.apply(this, arguments);
-  return Meteor.absoluteUrl(path.replace(/^\//, ''));
-};
-
-Router.prototype.go = function() {
-  // client only
-};
-
-Router.prototype.current = function() {
-  // We can't trust outside, that's why we clone this
-  // Anyway, we can't clone the whole object since it has non-jsonable values
-  // That's why we clone what's really needed.
-  var current = _.clone(this.currentRoute.get());
-  current.queryParams = EJSON.clone(current.queryParams);
-  current.params = EJSON.clone(current.params);
-  return current;
-};
-
-Router.prototype.getParam = function(key) {
-  var current = this.current();
-  if(current) {
-    return current.params[key];
+  
+  onRouteRegister(cb) {
+    this._onRouteCallbacks.push(cb);
   }
-};
-
-Router.prototype.getQueryParam = function(key) {
-  var current = this.current();
-  if(current) {
-    return current.queryParams[key];
+  
+  _triggerRouteRegister(currentRoute) {
+    // We should only need to send a safe set of fields on the route
+    // object.
+    // This is not to hide what's inside the route object, but to show 
+    // these are the public APIs
+    const routePublicApi = _.pick(currentRoute, 'name', 'pathDef', 'path');
+    const omittingOptionFields = [
+      'triggersEnter', 'triggersExit', 'action', 'subscriptions', 'name'
+    ];
+    routePublicApi.options = _.omit(currentRoute.options, omittingOptionFields);
+  
+    this._onRouteCallbacks.forEach((cb) => {
+      cb(routePublicApi);
+    });
   }
-};
-
-Router.prototype.getRouteName = function() {
-  var current = this.current();
-  if(current) {
-    return current.route.name;
+  
+  url() {
+    const path = this.path.apply(this, arguments);
+    return Meteor.absoluteUrl(path.replace(/^\//, ''));
   }
-};
+  
+  go() {
+    // client only
+  }
+  
+  current() {
+    // We can't trust outside, that's why we clone this
+    // Anyway, we can't clone the whole object since it has non-jsonable values
+    // That's why we clone what's really needed.
+    const current = _.clone(this.currentRoute.get());
+    current.queryParams = EJSON.clone(current.queryParams);
+    current.params = EJSON.clone(current.params);
+    return current;
+  }
+  
+  getParam(key) {
+    const current = this.current();
+    if(current) {
+      return current.params[key];
+    }
+  }
+  
+  getQueryParam(key) {
+    const current = this.current();
+    if(current) {
+      return current.queryParams[key];
+    }
+  }
+  
+  getRouteName() {
+    const current = this.current();
+    if(current) {
+      return current.route.name;
+    }
+  }
+  
+  watchPathChange() {
+  
+  }
+  
+  setDeferScriptLoading(defer) {
+    this.deferScriptLoading = defer;
+  }
+  
+  setPageCacheTimeout(timeout) {
+    this._pageCacheTimeout = timeout;
+  }
+}
 
+// Move this into the class declaration if possible.
+// Is there a reason this isn't in the constructor?
 Router.prototype.triggers = {
   enter: function() {
     // client only
@@ -135,28 +152,4 @@ Router.prototype.triggers = {
   exit: function() {
     // client only
   }
-};
-
-Router.prototype.ready = function() {
-  // client only
-};
-
-Router.prototype.initialize = function() {
-  // client only
-};
-
-Router.prototype.wait = function() {
-  // client only
-};
-
-Router.prototype.watchPathChange = function () {
-
-};
-
-Router.prototype.setDeferScriptLoading = function(defer) {
-  this.deferScriptLoading = defer;
-};
-
-Router.prototype.setPageCacheTimeout = function(timeout) {
-  this._pageCacheTimeout = timeout;
 };

--- a/server/ssr_context.js
+++ b/server/ssr_context.js
@@ -1,60 +1,60 @@
-var deepMerge = Npm.require('deepmerge');
+const deepMerge = Npm.require('deepmerge');
 
-SsrContext = function() {
-  this._html = "";
-  this._head = "";
-  this._collections = {};
-};
-
-SsrContext.prototype.getCollection = function(collName) {
-  var collection = this._collections[collName];
-  if(!collection) {
-    var minimongo = Package['minimongo'];
-    collection = this._collections[collName] = new minimongo.LocalCollection();
+SsrContext = class {
+  constructor() {
+    this._html = "";
+    this._head = "";
+    this._collections = {};
   }
 
-  return collection;
-};
+  getCollection(collName) {
+    let collection = this._collections[collName];
+    if(!collection) {
+      const minimongo = Package['minimongo'];
+      collection = this._collections[collName] = new minimongo.LocalCollection();
+    }
+  
+    return collection;
+  }
 
-SsrContext.prototype.setHtml = function(html) {
-  this._html = html;
-};
-
-SsrContext.prototype.getHtml = function() {
-  return this._html;
-};
-
-SsrContext.prototype.addToHead = function(headHtml) {
-  this._head += '\n' + headHtml;
-};
-
-SsrContext.prototype.getHead = function() {
-  return this._head;
-};
-
-SsrContext.prototype.addSubscription = function(name, params) {
-  var pub = Meteor.default_server.publish_handlers[name];
-  var fastRenderContext = FastRender.frContext.get();
-  var args = [name].concat(params);
-  var data = fastRenderContext.subscribe.apply(fastRenderContext, args);
-  this.addData(data);  
-};
-
-SsrContext.prototype.addData = function(data) {
-  var self = this;
-  _.each(data, function(collDataCollection, collectionName) {
-    var collection = self.getCollection(collectionName);
-    collDataCollection.forEach(function(collData) {
-      collData.forEach(function(item) {
-        var existingDoc = collection.findOne(item._id);
-        if(existingDoc) {
-          var newDoc = deepMerge(existingDoc, item);
-          delete newDoc._id;
-          collection.update(item._id, newDoc);
-        } else {
-          collection.insert(item);
-        }
+  setHtml(html) {
+    this._html = html;
+  }
+  
+  getHtml() {
+    return this._html;
+  }
+  
+  addToHead(headHtml) {
+    this._head += '\n' + headHtml;
+  }
+  
+  getHead() {
+    return this._head;
+  }
+  
+  addSubscription(name, params) {
+    const fastRenderContext = FastRender.frContext.get();
+    const args = [name].concat(params);
+    const data = fastRenderContext.subscribe.apply(fastRenderContext, args);
+    this.addData(data);  
+  }
+  
+  addData(data) {
+    _.each(data, (collDataCollection, collectionName) => {
+      const collection = this.getCollection(collectionName);
+      collDataCollection.forEach((collData) => {
+        collData.forEach((item) => {
+          const existingDoc = collection.findOne(item._id);
+          if(existingDoc) {
+            const newDoc = deepMerge(existingDoc, item);
+            delete newDoc._id;
+            collection.update(item._id, newDoc);
+          } else {
+            collection.insert(item);
+          }
+        });
       });
     });
-  });
-};
+  }
+}


### PR DESCRIPTION
added ecmascript package and removed use strict

updated meteor version to 1.2

removed window and switched to using built in forEach

converted client/groups.js to es2015

converted client/triggers.js to es2015

Converted server/group.js to es2015

Converted server/ssr_context.js to es2015 and removed an unnecessary line of code

Removed the following line from `addSubscription` since it doesn't seem to be doing anything:
`var pub = Meteor.default_server.publish_handlers[name];`

Converted server/route.js to es2015

Converted server/router.js to es2015

triggers still uses prototype. Not sure this is the best way to do this in ES2015. See end of server/router.js file

Converted server/plugins/ssr_data.js to es2015

Converted server/plugins/fast_render.js to es2015

Converted client/router.js to es2015

fixed a syntax error in client router

fixed more syntax errors in client router

Removed bugs I put into ssr_data.js with arrow functions and wrong this context

Fixed another error caused by this and arrow func

fixed some more bugs that were put into the code when converting to es2015

a few bug fixes

Made patch changes in server/route.js

Is this still needed since FR doesn't handle subs anymore?
```
    // process null subscriptions with FR support
    Picker.middleware(FastRender.handleOnAllRoutes);
```