### PR TITLE
Add http request object to route context

### DIFF
--- a/server/route.js
+++ b/server/route.js
@@ -50,7 +50,7 @@ Route = class {
       // We should not trigger any side effects
       params = _.clone(params);
       delete params.query;
-      const context = self._buildContext(req.url, params, queryParams);
+      const context = self._buildContext(req, params, queryParams);
   
       self._router.currentRoute.withValue(context, () => {
         try {
@@ -117,18 +117,19 @@ Route = class {
     const originalWrite = res.write;
     res.write = function (data) {
       originalWrite.call(this, pageInfo.html);
-    }
+    };
   
     res.pushData('fast-render-data', pageInfo.frData);
     next();
   }
   
-  _buildContext(url, params, queryParams) {
+  _buildContext(req, params, queryParams) {
     const context = {
       route: this,
-      path: url,
+      path: req.url,
       params: params,
-      queryParams: queryParams
+      queryParams: queryParams,
+      serverRequest: req
     };
   
     return context;


### PR DESCRIPTION
For SSR we sometimes need to know some meta information about the client requesting the page, such as the user-agent. This change will attach the entire HTTP request object to the context that is retrieved with `FlowRouter.current()`.

One use case is the `izzilab:material-ui` package which triggers the following error on server side rendering:

> Material-UI expects the global navigator.userAgent to be defined for server-side rendering. Set this property when receiving the request headers.

This pull request will allow for the following fix:

```JavaScript
if (Meteor.isServer) {
    let context = FlowRouter.current();
    navigator.userAgent = context.serverRequest.headers['user-agent'];
}

ReactLayout.render(MainLayout, {
  //...
});

if (Meteor.isServer) {
    delete navigator.userAgent;
}
```