### PR TITLE
Allow for undefined parameters

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -199,7 +199,8 @@ Router = class extends SharedRouter {
       if (matched) {
         const params = {};
         routeDef.keys.forEach(({name}, index) => {
-          params[name] = decodeURIComponent(matched[index + 1]);
+          const match = matched[index + 1];
+          params[name] = (typeof match !== 'undefined') ? decodeURIComponent(match) : match;
         });
 
         this._navigate(path, routeDef.route, params, parsedQueryParams);
@@ -309,7 +310,8 @@ Router = class extends SharedRouter {
   _encodeValues(obj) {
     const newObj = {};
     Object.keys(obj).forEach(key => {
-      newObj[key] = encodeURIComponent(obj[key]);
+      const value = obj[key];
+      newObj[key] = (typeof value !== 'undefined') ? encodeURIComponent(value) : value;
     });
 
     return newObj;
@@ -318,7 +320,8 @@ Router = class extends SharedRouter {
   _decodeValues(obj) {
     const newObj = {};
     Object.keys(obj).forEach(key => {
-      newObj[key] = decodeURIComponent(obj[key]);
+      const value = obj[key];
+      newObj[key] = (typeof value !== 'undefined') ? decodeURIComponent(value) : value;
     });
 
     return newObj;

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -39,6 +39,48 @@ function(test, next) {
   }, 100);
 });
 
+Tinytest.addAsync('Client - Router - define and go to route with optional fields',
+function(test, next) {
+  var rand = Random.id();
+  var pathDef = '/' + rand + '/:key?';
+  var rendered = 0;
+
+  FlowRouter.route(pathDef, {
+    action: function(params) {
+      test.equal(params.key, 'abc +@%');
+      rendered++;
+    }
+  });
+
+  FlowRouter.go(pathDef, {key: 'abc +@%'});
+
+  setTimeout(function() {
+    test.equal(rendered, 1);
+    setTimeout(next, 100);
+  }, 100);
+});
+
+Tinytest.addAsync('Client - Router - define and go to route with undefined optional fields',
+function(test, next) {
+  var rand = Random.id();
+  var pathDef = '/' + rand + '/:key?';
+  var rendered = 0;
+
+  FlowRouter.route(pathDef, {
+    action: function(params) {
+      test.isUndefined(params.key);
+      rendered++;
+    }
+  });
+
+  FlowRouter.go(pathDef, {});
+
+  setTimeout(function() {
+    test.equal(rendered, 1);
+    setTimeout(next, 100);
+  }, 100);
+});
+
 Tinytest.addAsync('Client - Router - parse params and query', function(test, next) {
   var rand = Random.id();
   var rendered = 0;
@@ -133,6 +175,41 @@ Tinytest.addAsync('Client - Router - setParams - generic', function(test, done) 
     test.equal(paramsList.length, 2);
     test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: '200'});
     test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: '700'});
+    done();
+  }
+});
+
+Tinytest.addAsync('Client - Router - setParams - optional', function(test, done) {
+  var randomKey = Random.id();
+  var pathDef = '/' + randomKey + '/:cat/:id?';
+  var paramsList = [];
+  FlowRouter.route(pathDef, {
+    action: function(params) {
+      paramsList.push(params);
+    }
+  });
+
+  FlowRouter.go(pathDef, {cat: 'meteor', id: '200'});
+  setTimeout(function() {
+    // return done();
+    var success = FlowRouter.setParams({id: '700'});
+    test.isTrue(success);
+    setTimeout(withUndefined, 50);
+  }, 50);
+
+  function withUndefined() {
+     var success = FlowRouter.setParams({id: undefined});
+     test.isTrue(success);
+     setTimeout(validate, 50);
+  }
+
+  function validate() {
+    test.equal(paramsList.length, 3);
+    test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: '200'});
+    test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: '700'});
+    test.equal(paramsList[2].cat, 'meteor');
+    test.isUndefined(paramsList[2].id);
+
     done();
   }
 });


### PR DESCRIPTION
3.8.0 broke optional parameters. For example, with a route defined as:

```
/:name?
```

`name` would be `"undefined"` (a string) instead of truly `undefined`.

Also, calling `setParams`or `setQueryParams` without setting a parameter would result an invalid path of a similar reason. In the example above, calling:

```
FlowRouter.setQueryParams({});
```

Would result in the router redirecting to `/undefined` instead of `/`
