### PR TITLE
Add '|' and '-' in regex fixes #479

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -90,17 +90,7 @@
       "version": "0.2.10"
     },
     "page": {
-      "version": "https://github.com/kadirahq/page.js/archive/34ddf45ea8e4c37269ce3df456b44fc0efc595c6.tar.gz",
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "1.2.1",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
-        }
-      }
+      "version": "https://github.com/kadirahq/page.js/archive/34ddf45ea8e4c37269ce3df456b44fc0efc595c6.tar.gz"
     },
     "path-to-regexp": {
       "version": "1.2.1",

--- a/client/router.js
+++ b/client/router.js
@@ -163,12 +163,6 @@ Router = class extends SharedRouter {
     return route;
   }
 
-  path(pathDef, fields = {}, queryParams = {}) {
-    const encodedFields = this._encodeValues(fields);
-    const encodedQueryParams = this._encodeValues(queryParams);
-    return super.path(pathDef, encodedFields, encodedQueryParams);
-  }
-
   go(pathDef, fields, queryParams) {
     const path = this.path(pathDef, fields, queryParams);
 
@@ -318,16 +312,6 @@ Router = class extends SharedRouter {
     );
 
     return redirectArgs;
-  }
-
-  _encodeValues(obj) {
-    const newObj = {};
-    Object.keys(obj).forEach(key => {
-      const value = obj[key];
-      newObj[key] = typeof value !== 'undefined' ? encodeURIComponent(value) : value;
-    });
-
-    return newObj;
   }
 
   _decodeValues(obj) {

--- a/client/router.js
+++ b/client/router.js
@@ -78,6 +78,13 @@ Router = class extends SharedRouter {
       ...existingParams,
       ...newParams
     };
+
+    for (const k in params) {
+      if (params[k] === null || params[k] === undefined) {
+        delete params[k];
+      }
+    }
+
     const queryParams = this._current.queryParams;
 
     this.go(pathDef, params, queryParams);

--- a/lib/router.js
+++ b/lib/router.js
@@ -35,7 +35,7 @@ SharedRouter = class {
 
   // XXX this function needs to be cleaned up if possible by removing `if (this.isServer)`
   // and `if (this.isClient)` if possible
-  path(pathDef, fields, queryParams) {
+  path(pathDef, fields = {}, queryParams = {}) {
     if (this._routesMap[pathDef]) {
       pathDef = this._routesMap[pathDef].path;
     }
@@ -47,9 +47,9 @@ SharedRouter = class {
       path += `/${this._basePath}/`;
     }
 
-    fields = fields || {};
+    // Encode query params
+    queryParams = this._encodeValues(queryParams);
 
-    fields = fields || {};
     const toPath = PathToRegexp.compile(pathDef);
     path += toPath(fields);
 
@@ -117,6 +117,16 @@ SharedRouter = class {
 
   onRouteRegister(cb) {
     this._onRouteCallbacks.push(cb);
+  }
+
+  _encodeValues(obj) {
+    const newObj = {};
+    Object.keys(obj).forEach(key => {
+      const value = obj[key];
+      newObj[key] = typeof value !== 'undefined' ? encodeURIComponent(value) : value;
+    });
+
+    return newObj;
   }
 
   _triggerRouteRegister(currentRoute) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -49,7 +49,7 @@ SharedRouter = class {
 
     fields = fields || {};
 
-    const regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
+    const regExp = /(:[\w\(\)\|\-\\\+\*\.\?]+)+/g;
 
     path += pathDef.replace(regExp, (key) => {
       const firstRegexpChar = key.indexOf('(');

--- a/lib/router.js
+++ b/lib/router.js
@@ -49,18 +49,17 @@ SharedRouter = class {
 
     fields = fields || {};
 
-    const regExp = /(:[\w\(\)\|\-\\\+\*\.\?]+)+/g;
+    fields = fields || {};
+    const toPath = PathToRegexp.compile(pathDef);
+    path += toPath(fields);
 
-    path += pathDef.replace(regExp, (key) => {
-      const firstRegexpChar = key.indexOf('(');
-      // get the content behind : and (\\d+/)
-      key = key.substring(1, firstRegexpChar > 0 ? firstRegexpChar : undefined);
-      // remove +?*
-      key = key.replace(/[\+\*\?]+/g, '');
-
-      const value = fields[key] || '';
-      return value;
-    });
+    // If we have one optional parameter in path definition e.g.
+    // /:category?
+    // and the parameter isn't present, path will be an empty string.
+    // We have this check as a value for path is required by e.g. FlowRouter.go()
+    if (!path) {
+      path = '/';
+    }
 
     // Replace multiple slashes with single slash
     path = path.replace(/\/\/+/g, '/');

--- a/server/_init.js
+++ b/server/_init.js
@@ -5,3 +5,4 @@
 // Now it's supported by SSR using this
 FlowRouter.basePath = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
 Qs = Npm.require('qs');
+PathToRegexp = Npm.require('path-to-regexp');

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -26,7 +26,7 @@ function(test, next) {
 
   FlowRouter.route(pathDef, {
     action: function(params) {
-      test.equal(params.key, 'abc +@%');
+      test.equal(params.key, encodeURIComponent('abc +@%'));
       rendered++;
     }
   });
@@ -47,7 +47,7 @@ function(test, next) {
 
   FlowRouter.route(pathDef, {
     action: function(params) {
-      test.equal(params.key, 'abc +@%');
+      test.equal(params.key, encodeURIComponent('abc +@%'));
       rendered++;
     }
   });
@@ -239,8 +239,8 @@ Tinytest.addAsync('Client - Router - setParams - preserve query strings', functi
     test.equal(paramsList.length, 2);
     test.equal(queryParamsList.length, 2);
 
-    test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: '200 +% / ad'});
-    test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: '700 +% / ad'});
+    test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: encodeURIComponent('200 +% / ad')});
+    test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: encodeURIComponent('700 +% / ad')});
     test.equal(queryParamsList, [{aa: '20 +%'}, {aa: '20 +%'}]);
     done();
   }

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -26,7 +26,7 @@ function(test, next) {
 
   FlowRouter.route(pathDef, {
     action: function(params) {
-      test.equal(params.key, encodeURIComponent('abc +@%'));
+      test.equal(params.key, 'abc +@%');
       rendered++;
     }
   });
@@ -47,7 +47,7 @@ function(test, next) {
 
   FlowRouter.route(pathDef, {
     action: function(params) {
-      test.equal(params.key, encodeURIComponent('abc +@%'));
+      test.equal(params.key, 'abc +@%');
       rendered++;
     }
   });
@@ -239,8 +239,8 @@ Tinytest.addAsync('Client - Router - setParams - preserve query strings', functi
     test.equal(paramsList.length, 2);
     test.equal(queryParamsList.length, 2);
 
-    test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: encodeURIComponent('200 +% / ad')});
-    test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: encodeURIComponent('700 +% / ad')});
+    test.equal(_.pick(paramsList[0], 'id', 'cat'), {cat: 'meteor', id: '200 +% / ad'});
+    test.equal(_.pick(paramsList[1], 'id', 'cat'), {cat: 'meteor', id: '700 +% / ad'});
     test.equal(queryParamsList, [{aa: '20 +%'}, {aa: '20 +%'}]);
     done();
   }

--- a/test/common/router.path.spec.js
+++ b/test/common/router.path.spec.js
@@ -60,8 +60,11 @@ Tinytest.add('Common - Router - path - missing fields', function(test) {
   };
   var expectedPath = '/blog/1001/some';
 
-  var path = FlowRouter.path(pathDef, fields);
-  test.equal(path, expectedPath);
+  try {
+    FlowRouter.path(pathDef, fields)
+  } catch (ex) {
+    test.isTrue(/Expected "name" to be defined/.test(ex.message));
+  }
 });
 
 Tinytest.add('Common - Router - path - no fields', function(test) {


### PR DESCRIPTION
As reported in #479 flow router wasn't working with certain regex in the path. This PR allows for path definitions such as:

`/blog/:action(edit|create)`

Added the hyphen to also allow for:

`/blog/:action(edit-page|create-page)`

There might be some other URL-friendly characters that need to be catered for but this should help in most cases!