### PR TITLE
Added option to initialize with trailing slashes

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -172,7 +172,7 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
   path = path.match(/^\/{1}$/) ? path: path.replace(/\/$/, "");
 
   // explictly asked to add a trailing slash
-  if(this.env.trailingSlash.get() && _.last(path) !== "/") {
+  if((this.env.trailingSlash.get() || this._addTrailingSlash) && _.last(path) !== "/") {
     path += "/";
   }
 
@@ -392,6 +392,8 @@ Router.prototype.initialize = function(options) {
     decodeURLComponents: true,
     hashbang: !!options.hashbang
   });
+
+  this._addTrailingSlash = !!options.addTrailingSlash;
 
   this._initialized = true;
 };


### PR DESCRIPTION
`FlowRouter.go` when run with url parameters, like `localhost/ -> localhost?foo=bar` will always remove the trailing slash. I added another initialization option `FlowRouter.initialize({addTrailingSlash: true});` to force FlowRouter to keep the trailing slash.