### PR TITLE
Delay handling of back button

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -37,7 +37,6 @@ Router = class extends SharedRouter {
 
     this._initTriggersAPI();
     this._initClickAnchorHandlers();
-    this._initiateHandlingBackButton();
   }
 
   initialize(options) {
@@ -49,6 +48,7 @@ Router = class extends SharedRouter {
 
     this._initialized = true;
     const path = location.pathname + location.search + (location.hash || '');
+    this._initiateHandlingBackButton();
     this.go(path);
   }
 


### PR DESCRIPTION
Delay handling of back button till the router get initialized. On Safari (OSX and iOS), a `onpopstate` event is triggered while the route aren't defined yet. The function associated to this event uses a `FlowRouter.go` with no route declared.

Fix tested on: Chrome (OSX & Android), Firefox, Safari (OSX & iOS).