### PR TITLE
When route not found during testing, don't log error

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -344,7 +344,10 @@ Router.prototype._notfoundRoute = function(context) {
   // XXX this.notfound kept for backwards compatibility
   this.notFound = this.notFound || this.notfound;
   if(!this.notFound) {
-    console.error("There is no route for the path:", context.path);
+    if(!Meteor.isTest && !Meteor.isPackageTest) {
+      console.error("There is no route for the path:", context.path);
+    }
+
     return;
   }
 


### PR DESCRIPTION
`meteor/todos` is currently throwing this error on the client during `meteor test`. 

https://github.com/meteor/todos/issues/130#issuecomment-217016579