### PR TITLE
.path not working for route regex ([0-9]*)

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -149,7 +149,7 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
   }
 
   fields = fields || {};
-  var regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
+  var regExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
   path += pathDef.replace(regExp, function(key) {
     var firstRegexpChar = key.indexOf("(");
     // get the content behind : and (\\d+/)

--- a/server/router.js
+++ b/server/router.js
@@ -37,7 +37,7 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
   }
 
   fields = fields || {};
-  var regExp = /(:[\w\(\)\\\+\*\.\?]+)+/g;
+  var regExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
   var path = pathDef.replace(regExp, function(key) {
     var firstRegexpChar = key.indexOf("(");
     // get the content behind : and (\\d+/)


### PR DESCRIPTION
See #653 

Changes the regex that detects regexes in the .path prototype.
Allows for [ ] and - characters.
