### PR TITLE
Fix nested groups on server

### DIFF
--- a/package.js
+++ b/package.js
@@ -42,6 +42,7 @@ Package.onTest(function(api) {
   api.addFiles('test/client/trigger.spec.js', 'client');
   api.addFiles('test/client/triggers.js', 'client');
 
+  api.addFiles('test/server/group.spec.js', 'server');
   api.addFiles('test/server/plugins/fast_render.js', 'server');
 
   api.addFiles('test/common/router.path.spec.js', ['client', 'server']);

--- a/server/group.js
+++ b/server/group.js
@@ -1,8 +1,20 @@
-Group = function(router, options) {
+Group = function(router, options, parent) {
   options = options || {};
-  this.prefix = options.prefix || '';
-  this.options = options;
+
+  if (options.prefix && !/^\/.*/.test(options.prefix)) {
+    var message = "group's prefix must start with '/'";
+    throw new Error(message);
+  }
+
   this._router = router;
+  this.prefix = options.prefix || '';
+  this.name = options.name;
+  this.options = options;
+
+  this.parent = parent;
+  if (this.parent) {
+    this.prefix = parent.prefix + this.prefix;
+  }
 };
 
 Group.prototype.route = function(pathDef, options) {
@@ -11,8 +23,5 @@ Group.prototype.route = function(pathDef, options) {
 };
 
 Group.prototype.group = function(options) {
-  var group = new Group(this._router, options);
-  group.parent = this;
-
-  return group;
+  return new Group(this._router, options, this);
 };

--- a/test/server/group.spec.js
+++ b/test/server/group.spec.js
@@ -1,0 +1,13 @@
+Tinytest.add('Server - Group - define route with nested prefix', function (test) {
+  var firstPrefix = Random.id();
+  var secondPrefix = Random.id();
+  var routePath = Random.id();
+  var routeName = Random.id();
+
+  var firstGroup = FlowRouter.group({prefix: '/' + firstPrefix});
+  var secondGroup = firstGroup.group({prefix: '/' + secondPrefix});
+
+  secondGroup.route('/' + routePath, {name: routeName});
+
+  test.equal(FlowRouter.path(routeName), '/' + firstPrefix + '/' + secondPrefix + '/' + routePath);
+});


### PR DESCRIPTION
I have multiple nested groups in a project, when on the client I've been using FlowRouter.path() it was working fine (/a/b/c), but on the server it only returned the last group's prefix (/b/c).
It turned out, that on the server the implementation of Group was not up-to-date with the client's implementation.
