### PR TITLE
Better handling of routing when stop is called from a trigger (both t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,44 @@ function localeCheck(context, redirect, stop) {
 
 > **Note**: When using the stop function, you should always pass the second **redirect** argument, even if you won't use it.
 
+> **Note**: After using the `stop` function in a `triggersExit` function, a duplicate history item (in the "next" slot) will be created. (Sorry...) But `triggersExit` triggers will fire again when attempting to route away once more.
+
+#### Triggers and their Invocation Context
+
+From the forgoing discussion, we learnt that that triggers are invoked with three arguments:
+ 1. `context`: information about the route (specifically, the output of `FlowRouter.current()`)
+ 2. `redirect`: a function that may be used for redirection to other routes
+ 3. `stop`: a function that aborts routing when invoked
+
+Additional information is available to entry/exit triggers in the form of their invocation context (i.e.: `this`).
+
+In particular, for entry triggers `this` takes the form:
+```javascript
+{
+  type: "enter",
+  route: /* new route */,
+  newRoute: /* new route */,
+  oldRoute: /* previous route */,
+  router: /* essentially FlowRouter */,
+  stopped: /* whether stop has been called */,
+  isReentrant: /* a boolean that indicates whether this entry is a
+                  result of re-entering a route after an exit is stopped
+                  using the stop function (third argument of a trigger) */
+}
+```
+
+In particular, and for exit triggers `this` takes the form:
+```javascript
+{
+  type: "exit",
+  route: /* current, soon to be former, route */,
+  oldRoute: /* current, soon to be former, route */,
+  router: /* essentially FlowRouter */,
+  stopped: /* whether stop has been called */
+}
+```
+
+
 ## Not Found Routes
 
 You can configure Not Found routes like this:

--- a/client/router.js
+++ b/client/router.js
@@ -102,7 +102,20 @@ Router.prototype.route = function(pathDef, options, group) {
     };
 
     var triggers = self._triggersEnter.concat(route._triggersEnter);
-    Triggers.runTriggers(
+    var triggersEnterInvocationContext = {
+      type: "enter",
+      route: route,
+      newRoute: route,
+      oldRoute: oldRoute,
+      router: self,
+      stopped: false,
+      isReentrant: !!self.__is_reentrant_following_stop_exit__
+    };
+    delete self.__is_reentrant_following_stop_exit__;
+
+    // triggers for entry aren't run when "going back to an old route"
+    // after stopping entry to another route
+    Triggers.runTriggers.call(triggersEnterInvocationContext,
       triggers,
       self._current,
       self._redirectFn,
@@ -113,7 +126,14 @@ Router.prototype.route = function(pathDef, options, group) {
   // calls when you exit from the page js route
   route._exitHandle = function(context, next) {
     var triggers = self._triggersExit.concat(route._triggersExit);
-    Triggers.runTriggers(
+    var triggersExitInvocationContext = {
+      type: "exit",
+      route: route,
+      oldRoute: route,
+      router: self,
+      stopped: false
+    };
+    Triggers.runTriggers.call(triggersExitInvocationContext,
       triggers,
       self._current,
       self._redirectFn,


### PR DESCRIPTION
Better handling of routing when stop is called from a trigger (both triggersEnter and triggersExit). In particular, triggersExit fires again after another exit attempt.

Using stop() in triggersExit results in a duplicate entry in the user's history will be created in the "next" slot. This is arguably a small price to pay for triggersExit firing again (on routing) after a stop.