### PR TITLE
OPTIONALLY better handling of routing when stop is called from a trigger (stop() generates current behaviour; stop(true) generates the new behaviour)

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -102,7 +102,22 @@ Router.prototype.route = function(pathDef, options, group) {
     };
 
     var triggers = self._triggersEnter.concat(route._triggersEnter);
-    Triggers.runTriggers(
+    var triggersEnterInvocationContext = {
+      type: "enter",
+      route: route,
+      newRoute: route,
+      oldRoute: oldRoute,
+      router: self,
+      stopped: false,
+      isReentrant_followingStoppedExit: !!self.__is_reentrant_following_stop_exit__,
+      isReentrant_followingStoppedEnter: !!self.__is_reentrant_following_stop_enter__
+    };
+    delete self.__is_reentrant_following_stop_exit__;
+    delete self.__is_reentrant_following_stop_enter__;
+
+    // triggers for entry aren't run when "going back to an old route"
+    // after stopping entry to another route
+    Triggers.runTriggers.call(triggersEnterInvocationContext,
       triggers,
       self._current,
       self._redirectFn,
@@ -113,7 +128,22 @@ Router.prototype.route = function(pathDef, options, group) {
   // calls when you exit from the page js route
   route._exitHandle = function(context, next) {
     var triggers = self._triggersExit.concat(route._triggersExit);
-    Triggers.runTriggers(
+    var triggersExitInvocationContext = {
+      type: "exit",
+      route: route,
+      oldRoute: route,
+      router: self,
+      stopped: false,
+      isReentrant_followingStoppedExit: !!self.__is_reentrant_following_stop_exit__,
+      isReentrant_followingStoppedEnter: !!self.__is_reentrant_following_stop_enter__
+    };
+
+    if (!self._current.path && !!self.__is_reentrant_following_stop_exit__) {
+      // patch up the path in a re-entrant exit
+      self._current.path = context.path;
+    }
+
+    Triggers.runTriggers.call(triggersExitInvocationContext,
       triggers,
       self._current,
       self._redirectFn,


### PR DESCRIPTION
OPTIONALLY better handling of routing when stop is called from a trigger (both triggersEnter and triggersExit). Original behaviour of FlowRouter is preserved.

stop has to be called with one argument (with value true; defaults to false, which generates the original behaviour)

With this tweak, triggersExit fires again after another exit attempt.

Using stop(true) in triggersExit results in a duplicate entry in the user's history will be created in the "next" slot. This is arguably a small price to pay for triggersExit firing again (on routing) after a stop.

Using stop(true) in triggersEnter results in a new entry in the user's history in the "next" slot for the route for which entry was stopped.