### PR TITLE
slow "time to first byte" on logged in state

### DIFF
--- a/server/route.js
+++ b/server/route.js
@@ -12,11 +12,16 @@ Route = class extends SharedRoute {
   _init() {
     const cookieParser = require('cookie-parser');
     Picker.middleware(cookieParser());
-    // process null subscriptions with FR support
-    Picker.middleware(FastRender.handleOnAllRoutes);
 
     const route = FlowRouter.basePath + this.pathDef;
-    Picker.route(route, this._handleRoute.bind(this));
+    
+    // only run fast render for defined routes
+    Picker.route(route, (params, req, res, next) => {
+      // process null subscriptions with FR support
+      FastRender.handleOnAllRoutes(req, res, () => {
+        this._handleRoute.bind(this)(params, req, res, next);
+      });
+    });
   }
 
   _handleRoute(params, req, res, next) {


### PR DESCRIPTION
When the user is logged in the browser measure for time to first byte is very slow (1.5s). I am testing with a remote mongodb which might contribute to the issue. In that situation also responses for js-files, assets and css all suffer the same initial delay. My debugging brought me to the conclusion that the handleOnAllRoutes has some side effect that is causing this. I do not see a reason why handleOnAllRoutes would need to run on every request and especially for static files / assets?
Therefore i wrapped the call to handleOnAllRoutes into the picker route when we are anticipating an html rendering to occur.