### PR TITLE
Add example: FlowRouter.subsReady(function() {} )

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,10 @@ Template.myTemplate.events({
       FlowRouter.subsReady("myPost", function() {
          // do something
       });
+      // Or, to run the callback when all subs are ready:
+      FlowRouter.subsReady(function() {
+         // do something
+      });
   }
 });
 ~~~


### PR DESCRIPTION
To show that you can wait on *all* subs before callback function runs.

Feedback is welcome!