### PR TITLE
fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This is how you can define triggers on a group definition.
 var adminRoutes = FlowRouter.group({
   prefix: '/admin',
   triggersEnter: [trackRouteEntry],
-  triggersExit: [trackRouteEntry]
+  triggersExit: [trackRouteExit]
 });
 ~~~
 


### PR DESCRIPTION
Changed function called on exit from `trackRouteEntry` to `trackRouteExit`.